### PR TITLE
Update atomicadd.clh

### DIFF
--- a/xfields/src/atomicadd.clh
+++ b/xfields/src/atomicadd.clh
@@ -15,7 +15,7 @@ inline void atomicAdd(volatile __global double *addr, double val)
 		next.f64 = expected.f64 + val;
 		current.u64 = atomic_cmpxchg(
 			(volatile __global unsigned long *)addr,
-		         expected.u64, next.u64);
+		        (unsigned int) expected.u64, (unsigned int) next.u64);
 	} while( current.u64 != expected.u64 );
 }
 #endif


### PR DESCRIPTION
Fixed the ambiguous function call bug on rocm opencl.
Before this patch, pyopencl stopped with the message

```
$ python 000_spacecharge_example.py 
WARNING: cupy is not installed, this context will not be available
/tmp/aoeftige/miniconda3/lib/python3.8/site-packages/pyopencl/__init__.py:266: CompilerWarning: Non-empty compiler output encountered. Set the environment variable PYOPENCL_COMPILER_OUTPUT=1 to see more.
  warn("Non-empty compiler output encountered. Set the "
<xobjects.context.context_pyopencl.ContextPyopencl object at 0x7f2619d0e580>
Traceback (most recent call last):
  File "000_spacecharge_example.py", line 61, in <module>
    spcharge = SpaceCharge3D(
  File "/tmp/aoeftige/xfields/xfields/beam_elements/spacecharge.py", line 91, in __init__
    fieldmap = TriLinearInterpolatedFieldMap(
  File "/tmp/aoeftige/xfields/xfields/fieldmaps/interpolated.py", line 79, in __init__
    add_default_kernels(context)
  File "/tmp/aoeftige/xfields/xfields/contexts/add_default_kernels.py", line 10, in add_default_kernels
    context.add_kernels(
  File "/tmp/aoeftige/xobjects/xobjects/context/context_pyopencl.py", line 164, in add_kernels
    prg = cl.Program(self.context, src_content).build()
  File "/tmp/aoeftige/miniconda3/lib/python3.8/site-packages/pyopencl/__init__.py", line 531, in build
    self._prg, was_cached = self._build_and_catch_errors(
  File "/tmp/aoeftige/miniconda3/lib/python3.8/site-packages/pyopencl/__init__.py", line 579, in _build_and_catch_errors
    raise err
pyopencl._cl.RuntimeError: clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE - clBuildProgram failed: BUILD_PROGRAM_FAILURE

Build on <pyopencl.Device 'gfx906+sram-ecc' on 'AMD Accelerated Parallel Processing' at 0x56053362ffe0>:

/tmp/comgr-c58442/input/CompileSource:21:17: error: call to 'atomic_cmpxchg' is ambiguous
                current.u64 = atomic_cmpxchg(
                              ^~~~~~~~~~~~~~
/data/jenkins_workspace/centos_pipeline_job_3.5/rocm-rel-3.5/rocm-3.5-30-20200528/7.5/out/centos-7/7/build/amd_comgr/<stdin>:13468:12: note: candidate function
int __ovld atomic_cmpxchg(volatile __global int *p, int cmp, int val);
           ^
/data/jenkins_workspace/centos_pipeline_job_3.5/rocm-rel-3.5/rocm-3.5-30-20200528/7.5/out/centos-7/7/build/amd_comgr/<stdin>:13469:21: note: candidate function
unsigned int __ovld atomic_cmpxchg(volatile __global unsigned int *p, unsigned int cmp, unsigned int val);
                    ^
1 error generated.
Error: Failed to compile opencl source (from CL or HIP source to LLVM IR).

(options: -I /tmp/aoeftige/miniconda3/lib/python3.8/site-packages/pyopencl/cl)
(source saved as /tmp/tmp7j8vn3us.cl)
```