### PR TITLE
fixes inconsistencies in examples

### DIFF
--- a/examples/exploratory_scripts/007_function_in_kernel/000_play.py
+++ b/examples/exploratory_scripts/007_function_in_kernel/000_play.py
@@ -5,8 +5,9 @@ from xobjects.context import available
 
 
 for (CTX, kwargs) in zip(
-        (xo.ContextCpu, xo.ContextPyopencl, xo.ContextCupy),
-        ({'omp_num_threads': 2}, {}, {})):
+    (xo.ContextCpu, xo.ContextPyopencl, xo.ContextCupy),
+    ({"omp_num_threads": 2}, {}, {}),
+):
 
     if CTX not in available:
         continue
@@ -14,7 +15,7 @@ for (CTX, kwargs) in zip(
     print(f"Test {CTX}")
     ctx = CTX(**kwargs)
 
-    src_code='''
+    src_code = """
     /*gpufun*/
     void myfun(double x, double y,
         double* z){
@@ -34,24 +35,24 @@ for (CTX, kwargs) in zip(
             }
         //end_vectorize
         }
-    '''
-    kernel_descriptions = {'my_mul':{
-        'args':(
-            (('scalar', np.int32),   'n',),
-            (('array',  np.float64), 'x1',),
-            (('array',  np.float64), 'x2',),
-            (('array',  np.float64), 'y',),
-            ),
-        'num_threads_from_arg': 'n'
-        },}
+    """
+    kernel_descriptions = {
+        "my_mul": xo.Kernel(
+            args=[
+                xo.Arg(xo.Int32, name="n"),
+                xo.Arg(xo.Float64, name="x1", const=True, pointer=True),
+                xo.Arg(xo.Float64, name="x2", const=True, pointer=True),
+                xo.Arg(xo.Float64, name="y", pointer=True),
+            ],
+            n_threads="n",
+        ),
+    }
 
     # Import kernel in context
-    ctx.add_kernels(src_code=src_code,
-            kernel_descriptions=kernel_descriptions,
-            save_src_as=None)
+    ctx.add_kernels(sources=[src_code], kernels=kernel_descriptions)
 
-    x1_host = np.array([1.,2.,3.], dtype=np.float64)
-    x2_host = np.array([7.,8.,9.], dtype=np.float64)
+    x1_host = np.array([1.0, 2.0, 3.0], dtype=np.float64)
+    x2_host = np.array([7.0, 8.0, 9.0], dtype=np.float64)
 
     x1_dev = ctx.nparray_to_context_array(x1_host)
     x2_dev = ctx.nparray_to_context_array(x2_host)
@@ -61,5 +62,4 @@ for (CTX, kwargs) in zip(
 
     y_host = ctx.nparray_from_context_array(y_dev)
 
-    assert np.allclose(y_host, x1_host*x2_host)
-
+    assert np.allclose(y_host, x1_host * x2_host)


### PR DESCRIPTION
- uses xobjects 'Kernel` and `Arg` classes to build the kernel_description dict
- uses correct keywords for the `add_kernels` call
- linting / autopep8