### PR TITLE
v0.7.1

### DIFF
--- a/tests/test_beambeam3d.py
+++ b/tests/test_beambeam3d.py
@@ -483,7 +483,7 @@ def test_beambeam3d_old_interface():
 
             bb_dtk.track(dtk_part)
 
-            part._move_to(_context=xo.ContextCpu())
+            part.move(_context=xo.ContextCpu())
             for cc in 'x px y py zeta delta'.split():
                 val_test = getattr(part, cc)[0]
                 val_ref = getattr(dtk_part, cc)

--- a/tests/test_electroncloud.py
+++ b/tests/test_electroncloud.py
@@ -77,7 +77,7 @@ def test_tricubic_interpolation():
                             zeta=beta0*tau_test, p0c=p0c)
         ecloud.track(part)
 
-        part._move_to(_context=xo.ContextCpu())
+        part.move(_context=xo.ContextCpu())
         mask_p = part.state != -11
         true_px = np.array([-dfdx(xx, yy, zz) for xx, yy, zz in zip(part.x[mask_p], part.y[mask_p],
                                                                     part.zeta[mask_p] / part.beta0[mask_p])])

--- a/xfields/beam_elements/beambeam2d.py
+++ b/xfields/beam_elements/beambeam2d.py
@@ -37,7 +37,7 @@ class BeamBeamBiGaussian2D(xt.BeamElement):
 
     }
 
-    extra_sources= [
+    _extra_c_source= [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('headers/sincos.h'),
         _pkg_root.joinpath('headers/power_n.h'),

--- a/xfields/beam_elements/beambeam2d.py
+++ b/xfields/beam_elements/beambeam2d.py
@@ -37,7 +37,7 @@ class BeamBeamBiGaussian2D(xt.BeamElement):
 
     }
 
-    _extra_c_source= [
+    _extra_c_sources= [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('headers/sincos.h'),
         _pkg_root.joinpath('headers/power_n.h'),

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -70,7 +70,7 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
     }
 
-    _extra_c_source= [
+    _extra_c_sources= [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('headers/sincos.h'),
         _pkg_root.joinpath('headers/power_n.h'),

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -70,7 +70,7 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
     }
 
-    extra_sources= [
+    _extra_c_source= [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('headers/sincos.h'),
         _pkg_root.joinpath('headers/power_n.h'),

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -84,7 +84,7 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
         _pkg_root.joinpath('beam_elements/beambeam_src/beambeam3d_methods_for_strongstrong.h'),
     ]
 
-    per_particle_kernels={
+    _per_particle_kernels={
         'synchro_beam_kick': xo.Kernel(
             c_name='BeamBeam3D_selective_apply_synchrobeam_kick_local_particle',
             args=[

--- a/xfields/beam_elements/electroncloud.py
+++ b/xfields/beam_elements/electroncloud.py
@@ -58,6 +58,12 @@ class ElectronCloud(xt.BeamElement):
         'fieldmap': xo.Ref(TriCubicInterpolatedFieldMap.XoStruct),
         }
 
+    _extra_c_source = [
+        _pkg_root.joinpath('fieldmaps/interpolated_src/tricubic_coefficients.h'),
+        _pkg_root.joinpath('fieldmaps/interpolated_src/cubic_interpolators.h'),
+        _pkg_root.joinpath('beam_elements/electroncloud_src/electroncloud.h'),
+    ]
+
     def __init__(self,
                  _context=None,
                  _buffer=None,
@@ -97,12 +103,3 @@ class ElectronCloud(xt.BeamElement):
                  dipolar_ptau_kick=dipolar_ptau_kick,
                  length=length,
                  fieldmap=fieldmap)
-
-
-
-srcs = []
-srcs.append(_pkg_root.joinpath('fieldmaps/interpolated_src/tricubic_coefficients.h'))
-srcs.append(_pkg_root.joinpath('fieldmaps/interpolated_src/cubic_interpolators.h'))
-srcs.append(_pkg_root.joinpath('beam_elements/electroncloud_src/electroncloud.h'))
-
-ElectronCloud.XoStruct.extra_sources = srcs

--- a/xfields/beam_elements/electroncloud.py
+++ b/xfields/beam_elements/electroncloud.py
@@ -58,7 +58,7 @@ class ElectronCloud(xt.BeamElement):
         'fieldmap': xo.Ref(TriCubicInterpolatedFieldMap.XoStruct),
         }
 
-    _extra_c_source = [
+    _extra_c_sources = [
         _pkg_root.joinpath('fieldmaps/interpolated_src/tricubic_coefficients.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/cubic_interpolators.h'),
         _pkg_root.joinpath('beam_elements/electroncloud_src/electroncloud.h'),

--- a/xfields/beam_elements/electroncloud.py
+++ b/xfields/beam_elements/electroncloud.py
@@ -55,7 +55,7 @@ class ElectronCloud(xt.BeamElement):
         'dipolar_ptau_kick': xo.Float64,
         'length': xo.Float64,
         #'fieldmap': TriCubicInterpolatedFieldMapData,
-        'fieldmap': xo.Ref(TriCubicInterpolatedFieldMap.XoStruct),
+        'fieldmap': xo.Ref(TriCubicInterpolatedFieldMap._XoStruct),
         }
 
     _extra_c_sources = [

--- a/xfields/beam_elements/electronlens_interpolated.py
+++ b/xfields/beam_elements/electronlens_interpolated.py
@@ -24,7 +24,7 @@ class ElectronLensInterpolated(xt.BeamElement):
                "fieldmap": TriCubicInterpolatedFieldMap.XoStruct,
               }
 
-    _extra_c_source = [
+    _extra_c_sources = [
         _pkg_root.joinpath('fieldmaps/interpolated_src/tricubic_coefficients.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/cubic_interpolators.h'),
         _pkg_root.joinpath('beam_elements/electronlens_src/electronlens_interpolated.h'),

--- a/xfields/beam_elements/electronlens_interpolated.py
+++ b/xfields/beam_elements/electronlens_interpolated.py
@@ -21,7 +21,7 @@ class ElectronLensInterpolated(xt.BeamElement):
                'current':  xo.Float64,
                'length':   xo.Float64,
                'voltage':  xo.Float64,
-               "fieldmap": TriCubicInterpolatedFieldMap.XoStruct,
+               "fieldmap": TriCubicInterpolatedFieldMap._XoStruct,
               }
 
     _extra_c_sources = [

--- a/xfields/beam_elements/electronlens_interpolated.py
+++ b/xfields/beam_elements/electronlens_interpolated.py
@@ -21,7 +21,7 @@ class ElectronLensInterpolated(xt.BeamElement):
                'current':  xo.Float64,
                'length':   xo.Float64,
                'voltage':  xo.Float64,
-               "fieldmap": TriCubicInterpolatedFieldMap._XoStruct,
+               "fieldmap": TriCubicInterpolatedFieldMap,
               }
 
     _extra_c_sources = [

--- a/xfields/beam_elements/electronlens_interpolated.py
+++ b/xfields/beam_elements/electronlens_interpolated.py
@@ -7,6 +7,7 @@ import numpy as np
 
 import xobjects as xo
 import xtrack as xt
+import xpart as xp
 
 from ..fieldmaps import TriLinearInterpolatedFieldMap
 from ..fieldmaps import TriCubicInterpolatedFieldMap
@@ -22,6 +23,12 @@ class ElectronLensInterpolated(xt.BeamElement):
                'voltage':  xo.Float64,
                "fieldmap": TriCubicInterpolatedFieldMap.XoStruct,
               }
+
+    _extra_c_source = [
+        _pkg_root.joinpath('fieldmaps/interpolated_src/tricubic_coefficients.h'),
+        _pkg_root.joinpath('fieldmaps/interpolated_src/cubic_interpolators.h'),
+        _pkg_root.joinpath('beam_elements/electronlens_src/electronlens_interpolated.h'),
+    ]
 
     def __init__(self,
                  _context=None,
@@ -128,11 +135,3 @@ class ElectronLensInterpolated(xt.BeamElement):
                  voltage=voltage,
                  fieldmap=tc_fieldmap)
 
-
-srcs = []
-srcs.append(_pkg_root.joinpath('headers/constants.h'))
-srcs.append(_pkg_root.joinpath('fieldmaps/interpolated_src/tricubic_coefficients.h'))
-srcs.append(_pkg_root.joinpath('fieldmaps/interpolated_src/cubic_interpolators.h'))
-srcs.append(_pkg_root.joinpath('beam_elements/electronlens_src/electronlens_interpolated.h'))
-
-ElectronLensInterpolated.XoStruct.extra_sources = srcs

--- a/xfields/beam_elements/spacecharge.py
+++ b/xfields/beam_elements/spacecharge.py
@@ -183,8 +183,8 @@ class SpaceCharge3D(xt.BeamElement):
 class SpaceChargeBiGaussian(xt.BeamElement):
 
     _xofields = {
-        'longitudinal_profile': LongitudinalProfileQGaussian._XoStruct, # TODO: Will become unionref
-        'fieldmap': BiGaussianFieldMap._XoStruct,
+        'longitudinal_profile': LongitudinalProfileQGaussian, # TODO: Will become unionref
+        'fieldmap': BiGaussianFieldMap,
         'length': xo.Float64,
         }
 

--- a/xfields/beam_elements/spacecharge.py
+++ b/xfields/beam_elements/spacecharge.py
@@ -77,6 +77,12 @@ class SpaceCharge3D(xt.BeamElement):
         'length': xo.Float64,
         }
 
+    _extra_c_source = [
+        _pkg_root.joinpath('headers/constants.h'),
+        _pkg_root.joinpath('fieldmaps/interpolated_src/linear_interpolators.h'),
+        _pkg_root.joinpath('beam_elements/spacecharge_src/spacecharge3d.h'),
+    ]
+
     def copy(self, _context=None, _buffer=None, _offset=None):
         if _buffer is not self._buffer:
             raise NotImplementedError
@@ -170,12 +176,7 @@ class SpaceCharge3D(xt.BeamElement):
         super().track(particles)
 
 
-srcs = []
-srcs.append(_pkg_root.joinpath('headers/constants.h'))
-srcs.append(_pkg_root.joinpath('fieldmaps/interpolated_src/linear_interpolators.h'))
-srcs.append(_pkg_root.joinpath('beam_elements/spacecharge_src/spacecharge3d.h'))
 
-SpaceCharge3D.XoStruct.extra_sources = srcs
 
 
 
@@ -186,6 +187,16 @@ class SpaceChargeBiGaussian(xt.BeamElement):
         'fieldmap': BiGaussianFieldMap.XoStruct,
         'length': xo.Float64,
         }
+
+    _extra_c_source = [
+        _pkg_root.joinpath('headers/constants.h'),
+        _pkg_root.joinpath('headers/sincos.h'),
+        _pkg_root.joinpath('headers/power_n.h'),
+        _pkg_root.joinpath('fieldmaps/bigaussian_src/complex_error_function.h'),
+        _pkg_root.joinpath('fieldmaps/bigaussian_src/bigaussian.h'),
+        _pkg_root.joinpath('longitudinal_profiles/qgaussian_src/qgaussian.h'),
+        _pkg_root.joinpath('beam_elements/spacecharge_src/spacechargebigaussian.h'),
+    ]
 
     def to_dict(self):
         dct = super().to_dict()
@@ -341,13 +352,4 @@ class SpaceChargeBiGaussian(xt.BeamElement):
         self.fieldmap.sigma_y = value
 
 
-srcs = []
-srcs.append(_pkg_root.joinpath('headers/constants.h'))
-srcs.append(_pkg_root.joinpath('headers/sincos.h'))
-srcs.append(_pkg_root.joinpath('headers/power_n.h'))
-srcs.append(_pkg_root.joinpath('fieldmaps/bigaussian_src/complex_error_function.h'))
-srcs.append(_pkg_root.joinpath('fieldmaps/bigaussian_src/bigaussian.h'))
-srcs.append(_pkg_root.joinpath('longitudinal_profiles/qgaussian_src/qgaussian.h'))
-srcs.append(_pkg_root.joinpath('beam_elements/spacecharge_src/spacechargebigaussian.h'))
 
-SpaceChargeBiGaussian.XoStruct.extra_sources = srcs

--- a/xfields/beam_elements/spacecharge.py
+++ b/xfields/beam_elements/spacecharge.py
@@ -77,7 +77,7 @@ class SpaceCharge3D(xt.BeamElement):
         'length': xo.Float64,
         }
 
-    _extra_c_source = [
+    _extra_c_sources = [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/linear_interpolators.h'),
         _pkg_root.joinpath('beam_elements/spacecharge_src/spacecharge3d.h'),
@@ -188,7 +188,7 @@ class SpaceChargeBiGaussian(xt.BeamElement):
         'length': xo.Float64,
         }
 
-    _extra_c_source = [
+    _extra_c_sources = [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('headers/sincos.h'),
         _pkg_root.joinpath('headers/power_n.h'),

--- a/xfields/beam_elements/spacecharge.py
+++ b/xfields/beam_elements/spacecharge.py
@@ -73,7 +73,7 @@ class SpaceCharge3D(xt.BeamElement):
         (SpaceCharge3D): A space-charge 3D beam element.
     """
     _xofields = {
-        'fieldmap': xo.Ref(TriLinearInterpolatedFieldMap.XoStruct),
+        'fieldmap': xo.Ref(TriLinearInterpolatedFieldMap._XoStruct),
         'length': xo.Float64,
         }
 
@@ -183,8 +183,8 @@ class SpaceCharge3D(xt.BeamElement):
 class SpaceChargeBiGaussian(xt.BeamElement):
 
     _xofields = {
-        'longitudinal_profile': LongitudinalProfileQGaussian.XoStruct, # TODO: Will become unionref
-        'fieldmap': BiGaussianFieldMap.XoStruct,
+        'longitudinal_profile': LongitudinalProfileQGaussian._XoStruct, # TODO: Will become unionref
+        'fieldmap': BiGaussianFieldMap._XoStruct,
         'length': xo.Float64,
         }
 

--- a/xfields/config_tools/spacecharge_config_tools.py
+++ b/xfields/config_tools/spacecharge_config_tools.py
@@ -88,7 +88,7 @@ def replace_spacecharge_with_quasi_frozen(
     spch_elements = []
     for ii, ee in enumerate(line.elements):
         if isinstance(ee, SpaceChargeBiGaussian):
-            ee._move_to(_buffer=_buffer)
+            ee.move(_buffer=_buffer)
             ee.update_mean_x_on_track = update_mean_x_on_track
             ee.update_mean_y_on_track = update_mean_y_on_track
             ee.update_sigma_x_on_track = update_sigma_x_on_track

--- a/xfields/fieldmaps/interpolated.py
+++ b/xfields/fieldmaps/interpolated.py
@@ -29,7 +29,7 @@ _TriLinearInterpolatedFielmap_kernels = {
     'p2m_rectmesh3d_xparticles': xo.Kernel(
         args=[
             xo.Arg(xo.Int32,   pointer=False, name='nparticles'),
-            xo.Arg(xp.Particles._XoStruct, pointer=False, name='particles'),
+            xo.Arg(xp.Particles, pointer=False, name='particles'),
             xo.Arg(xo.Float64, pointer=False, name='x0'),
             xo.Arg(xo.Float64, pointer=False, name='y0'),
             xo.Arg(xo.Float64, pointer=False, name='z0'),
@@ -163,7 +163,7 @@ class TriLinearInterpolatedFieldMap(xo.HybridClass):
         _pkg_root.joinpath('fieldmaps/interpolated_src/charge_deposition.h'),
         ]
 
-    _depends_on = [xp.Particles._XoStruct]
+    _depends_on = [xp.Particles]
 
     _kernels = _TriLinearInterpolatedFielmap_kernels
 

--- a/xfields/fieldmaps/interpolated.py
+++ b/xfields/fieldmaps/interpolated.py
@@ -86,12 +86,14 @@ class TriLinearInterpolatedFieldMap(xo.HybridClass):
     # properties
     _rename = {nn: '_'+nn for nn in _xofields}
 
-    extra_sources = [
+    _extra_c_source = [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/central_diff.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/linear_interpolators.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/charge_deposition.h'),
         ]
+
+    _depends_on = [xp.Particles.XoStruct]
 
     def __init__(self,
                  _context=None,

--- a/xfields/fieldmaps/interpolated.py
+++ b/xfields/fieldmaps/interpolated.py
@@ -29,7 +29,7 @@ _TriLinearInterpolatedFielmap_kernels = {
     'p2m_rectmesh3d_xparticles': xo.Kernel(
         args=[
             xo.Arg(xo.Int32,   pointer=False, name='nparticles'),
-            xo.Arg(xp.Particles.XoStruct, pointer=False, name='particles'),
+            xo.Arg(xp.Particles._XoStruct, pointer=False, name='particles'),
             xo.Arg(xo.Float64, pointer=False, name='x0'),
             xo.Arg(xo.Float64, pointer=False, name='y0'),
             xo.Arg(xo.Float64, pointer=False, name='z0'),
@@ -163,7 +163,7 @@ class TriLinearInterpolatedFieldMap(xo.HybridClass):
         _pkg_root.joinpath('fieldmaps/interpolated_src/charge_deposition.h'),
         ]
 
-    _depends_on = [xp.Particles.XoStruct]
+    _depends_on = [xp.Particles._XoStruct]
 
     _kernels = _TriLinearInterpolatedFielmap_kernels
 

--- a/xfields/fieldmaps/interpolated.py
+++ b/xfields/fieldmaps/interpolated.py
@@ -156,7 +156,7 @@ class TriLinearInterpolatedFieldMap(xo.HybridClass):
     # properties
     _rename = {nn: '_'+nn for nn in _xofields}
 
-    _extra_c_source = [
+    _extra_c_sources = [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/central_diff.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/linear_interpolators.h'),

--- a/xfields/fieldmaps/tricubicinterpolated.py
+++ b/xfields/fieldmaps/tricubicinterpolated.py
@@ -7,7 +7,6 @@ import numpy as np
 
 import xobjects as xo
 import xpart as xp
-import xtrack as xt
 
 from .interpolated import _configure_grid
 from ..general import _pkg_root
@@ -98,13 +97,15 @@ class TriCubicInterpolatedFieldMap(xo.HybridClass):
     # properties
     _rename = {nn: '_'+nn for nn in _xofields}
 
-    extra_sources = [
+    _extra_c_source = [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/tricubic_coefficients.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/cubic_interpolators.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/central_diff.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/charge_deposition.h'),
         ]
+
+    _depends_on = [xp.Particles.XoStruct]
 
 
     def __init__(self,

--- a/xfields/fieldmaps/tricubicinterpolated.py
+++ b/xfields/fieldmaps/tricubicinterpolated.py
@@ -28,7 +28,7 @@ _TriCubicInterpolatedFieldMap_kernels = {
     'p2m_rectmesh3d_xparticles': xo.Kernel(
         args=[
             xo.Arg(xo.Int32,   pointer=False, name='nparticles'),
-            xo.Arg(xp.Particles.XoStruct, pointer=False, name='particles'),
+            xo.Arg(xp.Particles._XoStruct, pointer=False, name='particles'),
             xo.Arg(xo.Float64, pointer=False, name='x0'),
             xo.Arg(xo.Float64, pointer=False, name='y0'),
             xo.Arg(xo.Float64, pointer=False, name='z0'),
@@ -161,7 +161,7 @@ class TriCubicInterpolatedFieldMap(xo.HybridClass):
         _pkg_root.joinpath('fieldmaps/interpolated_src/charge_deposition.h'),
         ]
 
-    _depends_on = [xp.Particles.XoStruct]
+    _depends_on = [xp.Particles._XoStruct]
 
     _kernels = _TriCubicInterpolatedFieldMap_kernels
 

--- a/xfields/fieldmaps/tricubicinterpolated.py
+++ b/xfields/fieldmaps/tricubicinterpolated.py
@@ -11,6 +11,62 @@ import xpart as xp
 from .interpolated import _configure_grid
 from ..general import _pkg_root
 
+_TriCubicInterpolatedFieldMap_kernels = {
+    'central_diff': xo.Kernel(
+        args=[
+            xo.Arg(xo.Int32,   pointer=False, name='nelem'),
+            xo.Arg(xo.Int32,   pointer=False, name='row_size'),
+            xo.Arg(xo.Int32,   pointer=False, name='stride_in_dbl'),
+            xo.Arg(xo.Float64, pointer=False, name='factor'),
+            xo.Arg(xo.Int8,    pointer=True,  name='matrix_buffer'),
+            xo.Arg(xo.Int64,   pointer=False, name='matrix_offset'),
+            xo.Arg(xo.Int8,    pointer=True,  name='res_buffer'),
+            xo.Arg(xo.Int64,   pointer=False, name='res_offset'),
+            ],
+        n_threads='nelem'
+        ),
+    'p2m_rectmesh3d_xparticles': xo.Kernel(
+        args=[
+            xo.Arg(xo.Int32,   pointer=False, name='nparticles'),
+            xo.Arg(xp.Particles.XoStruct, pointer=False, name='particles'),
+            xo.Arg(xo.Float64, pointer=False, name='x0'),
+            xo.Arg(xo.Float64, pointer=False, name='y0'),
+            xo.Arg(xo.Float64, pointer=False, name='z0'),
+            xo.Arg(xo.Float64, pointer=False, name='dx'),
+            xo.Arg(xo.Float64, pointer=False, name='dy'),
+            xo.Arg(xo.Float64, pointer=False, name='dz'),
+            xo.Arg(xo.Int32,   pointer=False, name='nx'),
+            xo.Arg(xo.Int32,   pointer=False, name='ny'),
+            xo.Arg(xo.Int32,   pointer=False, name='nz'),
+            xo.Arg(xo.Int8,    pointer=True,  name='grid1d_buffer'),
+            xo.Arg(xo.Int64,   pointer=False, name='grid1d_offset'),
+            ],
+        n_threads='nparticles'
+        ),
+    'p2m_rectmesh3d': xo.Kernel(
+        args=[
+            xo.Arg(xo.Int32,   pointer=False, name='nparticles'),
+            xo.Arg(xo.Float64, pointer=True, name='x'),
+            xo.Arg(xo.Float64, pointer=True, name='y'),
+            xo.Arg(xo.Float64, pointer=True, name='z'),
+            xo.Arg(xo.Float64, pointer=True, name='part_weights'),
+            xo.Arg(xo.Int64,   pointer=True, name='part_state'),
+            xo.Arg(xo.Float64, pointer=False, name='x0'),
+            xo.Arg(xo.Float64, pointer=False, name='y0'),
+            xo.Arg(xo.Float64, pointer=False, name='z0'),
+            xo.Arg(xo.Float64, pointer=False, name='dx'),
+            xo.Arg(xo.Float64, pointer=False, name='dy'),
+            xo.Arg(xo.Float64, pointer=False, name='dz'),
+            xo.Arg(xo.Int32,   pointer=False, name='nx'),
+            xo.Arg(xo.Int32,   pointer=False, name='ny'),
+            xo.Arg(xo.Int32,   pointer=False, name='nz'),
+            xo.Arg(xo.Int8,    pointer=True,  name='grid1d_buffer'),
+            xo.Arg(xo.Int64,   pointer=False, name='grid1d_offset'),
+            ],
+        n_threads='nparticles'
+        ),
+    }
+
 
 class TriCubicInterpolatedFieldMap(xo.HybridClass):
 
@@ -107,6 +163,8 @@ class TriCubicInterpolatedFieldMap(xo.HybridClass):
 
     _depends_on = [xp.Particles.XoStruct]
 
+    _kernels = _TriCubicInterpolatedFieldMap_kernels
+
 
     def __init__(self,
                  _context=None,
@@ -157,7 +215,8 @@ class TriCubicInterpolatedFieldMap(xo.HybridClass):
                  phi_taylor = nelem
                  )
 
-        self.compile_custom_kernels(only_if_needed=True)
+        self.compile_kernels(only_if_needed=True)
+
         if phi_taylor is not None:
             self.phi_taylor = phi_taylor
         else:
@@ -459,58 +518,4 @@ class TriCubicInterpolatedFieldMap(xo.HybridClass):
         """
         return self.z_grid[1] - self.z_grid[0]
 
-TriCubicInterpolatedFieldMap.XoStruct.custom_kernels = {
-    'central_diff': xo.Kernel(
-        args=[
-            xo.Arg(xo.Int32,   pointer=False, name='nelem'),
-            xo.Arg(xo.Int32,   pointer=False, name='row_size'),
-            xo.Arg(xo.Int32,   pointer=False, name='stride_in_dbl'),
-            xo.Arg(xo.Float64, pointer=False, name='factor'),
-            xo.Arg(xo.Int8,    pointer=True,  name='matrix_buffer'),
-            xo.Arg(xo.Int64,   pointer=False, name='matrix_offset'),
-            xo.Arg(xo.Int8,    pointer=True,  name='res_buffer'),
-            xo.Arg(xo.Int64,   pointer=False, name='res_offset'),
-            ],
-        n_threads='nelem'
-        ),
-    'p2m_rectmesh3d_xparticles': xo.Kernel(
-        args=[
-            xo.Arg(xo.Int32,   pointer=False, name='nparticles'),
-            xo.Arg(xp.Particles.XoStruct, pointer=False, name='particles'),
-            xo.Arg(xo.Float64, pointer=False, name='x0'),
-            xo.Arg(xo.Float64, pointer=False, name='y0'),
-            xo.Arg(xo.Float64, pointer=False, name='z0'),
-            xo.Arg(xo.Float64, pointer=False, name='dx'),
-            xo.Arg(xo.Float64, pointer=False, name='dy'),
-            xo.Arg(xo.Float64, pointer=False, name='dz'),
-            xo.Arg(xo.Int32,   pointer=False, name='nx'),
-            xo.Arg(xo.Int32,   pointer=False, name='ny'),
-            xo.Arg(xo.Int32,   pointer=False, name='nz'),
-            xo.Arg(xo.Int8,    pointer=True,  name='grid1d_buffer'),
-            xo.Arg(xo.Int64,   pointer=False, name='grid1d_offset'),
-            ],
-        n_threads='nparticles'
-        ),
-    'p2m_rectmesh3d': xo.Kernel(
-        args=[
-            xo.Arg(xo.Int32,   pointer=False, name='nparticles'),
-            xo.Arg(xo.Float64, pointer=True, name='x'),
-            xo.Arg(xo.Float64, pointer=True, name='y'),
-            xo.Arg(xo.Float64, pointer=True, name='z'),
-            xo.Arg(xo.Float64, pointer=True, name='part_weights'),
-            xo.Arg(xo.Int64,   pointer=True, name='part_state'),
-            xo.Arg(xo.Float64, pointer=False, name='x0'),
-            xo.Arg(xo.Float64, pointer=False, name='y0'),
-            xo.Arg(xo.Float64, pointer=False, name='z0'),
-            xo.Arg(xo.Float64, pointer=False, name='dx'),
-            xo.Arg(xo.Float64, pointer=False, name='dy'),
-            xo.Arg(xo.Float64, pointer=False, name='dz'),
-            xo.Arg(xo.Int32,   pointer=False, name='nx'),
-            xo.Arg(xo.Int32,   pointer=False, name='ny'),
-            xo.Arg(xo.Int32,   pointer=False, name='nz'),
-            xo.Arg(xo.Int8,    pointer=True,  name='grid1d_buffer'),
-            xo.Arg(xo.Int64,   pointer=False, name='grid1d_offset'),
-            ],
-        n_threads='nparticles'
-        ),
-    }
+

--- a/xfields/fieldmaps/tricubicinterpolated.py
+++ b/xfields/fieldmaps/tricubicinterpolated.py
@@ -153,7 +153,7 @@ class TriCubicInterpolatedFieldMap(xo.HybridClass):
     # properties
     _rename = {nn: '_'+nn for nn in _xofields}
 
-    _extra_c_source = [
+    _extra_c_sources = [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/tricubic_coefficients.h'),
         _pkg_root.joinpath('fieldmaps/interpolated_src/cubic_interpolators.h'),

--- a/xfields/fieldmaps/tricubicinterpolated.py
+++ b/xfields/fieldmaps/tricubicinterpolated.py
@@ -28,7 +28,7 @@ _TriCubicInterpolatedFieldMap_kernels = {
     'p2m_rectmesh3d_xparticles': xo.Kernel(
         args=[
             xo.Arg(xo.Int32,   pointer=False, name='nparticles'),
-            xo.Arg(xp.Particles._XoStruct, pointer=False, name='particles'),
+            xo.Arg(xp.Particles, pointer=False, name='particles'),
             xo.Arg(xo.Float64, pointer=False, name='x0'),
             xo.Arg(xo.Float64, pointer=False, name='y0'),
             xo.Arg(xo.Float64, pointer=False, name='z0'),
@@ -161,7 +161,7 @@ class TriCubicInterpolatedFieldMap(xo.HybridClass):
         _pkg_root.joinpath('fieldmaps/interpolated_src/charge_deposition.h'),
         ]
 
-    _depends_on = [xp.Particles._XoStruct]
+    _depends_on = [xp.Particles]
 
     _kernels = _TriCubicInterpolatedFieldMap_kernels
 

--- a/xfields/longitudinal_profiles/qgaussian.py
+++ b/xfields/longitudinal_profiles/qgaussian.py
@@ -12,13 +12,6 @@ from scipy.special import gamma
 
 from ..general import _pkg_root
 
-
-
-
-
-
-
-
 class LongitudinalProfileQGaussian(xo.HybridClass):
 
     _xofields = {
@@ -34,7 +27,7 @@ class LongitudinalProfileQGaussian(xo.HybridClass):
         '_support_max': xo.Float64,
     }
 
-    extra_sources = [
+    _extra_c_source = [
         _pkg_root.joinpath('longitudinal_profiles/qgaussian_src/qgaussian.h')
         ]
 

--- a/xfields/longitudinal_profiles/qgaussian.py
+++ b/xfields/longitudinal_profiles/qgaussian.py
@@ -27,7 +27,7 @@ class LongitudinalProfileQGaussian(xo.HybridClass):
         '_support_max': xo.Float64,
     }
 
-    _extra_c_source = [
+    _extra_c_sources = [
         _pkg_root.joinpath('longitudinal_profiles/qgaussian_src/qgaussian.h')
         ]
 

--- a/xfields/longitudinal_profiles/qgaussian.py
+++ b/xfields/longitudinal_profiles/qgaussian.py
@@ -31,6 +31,13 @@ class LongitudinalProfileQGaussian(xo.HybridClass):
         _pkg_root.joinpath('longitudinal_profiles/qgaussian_src/qgaussian.h')
         ]
 
+    _kernels = {'line_density_qgauss':
+        xo.Kernel(args=[xo.Arg(xo.ThisClass, name='prof'),
+                        xo.Arg(xo.Int64, name='n'),
+                        xo.Arg(xo.Float64, pointer=True, name='z'),
+                        xo.Arg(xo.Float64, pointer=True, name='res')],
+                  n_threads='n')}
+
     @staticmethod
     def cq_from_q(q, q_tol):
         cq = sqrt(pi)
@@ -165,15 +172,9 @@ class LongitudinalProfileQGaussian(xo.HybridClass):
         res = context.zeros(len(z), dtype=np.float64)
 
         if 'line_density_q_gauss' not in context.kernels.keys():
-            self.compile_custom_kernels()
+            self.compile_kernels()
 
         context.kernels.line_density_qgauss(prof=self._xobject, n=len(z), z=z, res=res)
 
         return res
 
-LongitudinalProfileQGaussian.XoStruct.custom_kernels = {'line_density_qgauss':
-        xo.Kernel(args=[xo.Arg(LongitudinalProfileQGaussian.XoStruct, name='prof'),
-                        xo.Arg(xo.Int64, name='n'),
-                        xo.Arg(xo.Float64, pointer=True, name='z'),
-                        xo.Arg(xo.Float64, pointer=True, name='res')],
-                  n_threads='n')}


### PR DESCRIPTION
**Changes**
 
Adapted to new Xobjects and Xtrack API:
 - C source code provided in ```_extra_c_sources``` inside class declaration, ```_move_to``` renamed to ```move```, ```XoStruct``` renamed to ```_XoStruct```).
 - Kernel declarations can be provided through the ```_kernel``` dictionary when subclassing ```BeamElement```.
 - Renamed ```per_particle_kernels``` to ```_per_particle_kernels```.

