### PR TITLE
don't require gpyfft for test, as it's not needed on CPU

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
             "Source Code": "https://github.com/xsuite/xfields",
         },
     extras_require={
-            'tests': ['gpyfft', 'pytest']
+            'tests': ['pytest'],
         },
     )


### PR DESCRIPTION
## Description

Currently the tests break on github runners because `gpyfft` is required as a test dependency, even though it is not actually required on the CPU context. This removes this requirement.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones (https://github.com/szymonlopaciuk/xsuite/actions/runs/3264068031)
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
