### PR TITLE
move beamstrahlung, bhabha, lumi computation into separate functions

### DIFF
--- a/tests/test_lumi.py
+++ b/tests/test_lumi.py
@@ -12,7 +12,7 @@ import xpart as xp
 from xobjects.test_helpers import for_all_test_contexts
 
 @for_all_test_contexts
-def test_beambeam3d_bhabha_ws_no_config(test_context):
+def test_beambeam3d_lumi_ws_no_config(test_context):
 
     if isinstance(test_context, xo.ContextCupy):
         import cupy as cp
@@ -92,10 +92,8 @@ def test_beambeam3d_bhabha_ws_no_config(test_context):
     line = xt.Line(elements = [el_beambeam_b1])
     line.build_tracker(_context=test_context)
 
-    assert line._needs_rng == False
-
     record_ws_b1 = line.start_internal_logging_for_elements_of_type(
-        xf.BeamBeamBiGaussian3D, capacity={"beamstrahlungtable": int(0), "bhabhatable": int(0), "lumitable": int(n_slices*n_macroparticles_b1)})
+        xf.BeamBeamBiGaussian3D, capacity={"beamstrahlungtable": int(0), "bhabhatable": int(0), "lumitable": int(1)})
     line.track(particles_b1, num_turns=1)
     line.stop_internal_logging_for_elements_of_type(xf.BeamBeamBiGaussian3D)
 
@@ -109,7 +107,7 @@ def test_beambeam3d_bhabha_ws_no_config(test_context):
     piwi    = sigma_z_tot / sigma_x * phi  # [1]
     lumi_ip = bunch_intensity**2 / (4*np.pi*sigma_x*np.sqrt(1 + piwi**2)*sigma_y)  # [m^-2] for 1 IP
 
-    lumi_ws_b1 = np.sum(record_ws_b1.lumitable.luminosity)
+    lumi_ws_b1 = record_ws_b1.lumitable.luminosity[0]
     rel_err_ws_b1 = 100*(lumi_ws_b1 - lumi_ip) / lumi_ip
     print("WS beam 1:", lumi_ws_b1, rel_err_ws_b1, "[%]")
 
@@ -117,7 +115,7 @@ def test_beambeam3d_bhabha_ws_no_config(test_context):
     assert np.allclose(lumi_ws_b1, lumi_ip, rtol=1.5e-1, atol=0)
 
 @for_all_test_contexts
-def test_beambeam3d_bhabha_ws_config(test_context):
+def test_beambeam3d_lumi_ws_config(test_context):
 
     if isinstance(test_context, xo.ContextPyopencl):
         pytest.skip("Not implemented for OpenCL")
@@ -213,13 +211,8 @@ def test_beambeam3d_bhabha_ws_config(test_context):
     line = xt.Line(elements = [el_beambeam_b1])
     line.build_tracker(_context=test_context)
 
-    assert line._needs_rng == False
-
-    line.configure_radiation(model_bhabha='quantum')
-    assert line._needs_rng == True
-
     record_ws_b1 = line.start_internal_logging_for_elements_of_type(
-        xf.BeamBeamBiGaussian3D, capacity={"beamstrahlungtable": int(0), "bhabhatable": int(0), "lumitable": int(n_slices*n_macroparticles_b1)})
+        xf.BeamBeamBiGaussian3D, capacity={"beamstrahlungtable": int(0), "bhabhatable": int(0), "lumitable": int(1)})
     line.track(particles_b1, num_turns=1)
     line.stop_internal_logging_for_elements_of_type(xf.BeamBeamBiGaussian3D)
 
@@ -233,7 +226,7 @@ def test_beambeam3d_bhabha_ws_config(test_context):
     piwi    = sigma_z_tot / sigma_x * phi  # [1]
     lumi_ip = bunch_intensity**2 / (4*np.pi*sigma_x*np.sqrt(1 + piwi**2)*sigma_y)  # [m^-2] for 1 IP
 
-    lumi_ws_b1 = np.sum(record_ws_b1.lumitable.luminosity)
+    lumi_ws_b1 = record_ws_b1.lumitable.luminosity[0]
     rel_err_ws_b1 = 100*(lumi_ws_b1 - lumi_ip) / lumi_ip
     print("WS beam 1:", lumi_ws_b1, rel_err_ws_b1, "[%]")
 
@@ -242,7 +235,7 @@ def test_beambeam3d_bhabha_ws_config(test_context):
 
 
 @for_all_test_contexts
-def test_beambeam3d_bhabha_qss(test_context):
+def test_beambeam3d_lumi_qss(test_context):
 
     if isinstance(test_context, xo.ContextPyopencl):
         pytest.skip("Not implemented for OpenCL")
@@ -375,15 +368,6 @@ def test_beambeam3d_bhabha_qss(test_context):
     line_b1.build_tracker(_context=test_context)
     line_b2.build_tracker(_context=test_context)
 
-    assert line_b1._needs_rng == False
-    assert line_b2._needs_rng == False
-
-    line_b1.configure_radiation(model_bhabha='quantum')
-    line_b2.configure_radiation(model_bhabha='quantum')
-
-    assert line_b1._needs_rng == True
-    assert line_b2._needs_rng == True
-
     particles_b1.name = "b1"
     particles_b2.name = "b2"
 
@@ -395,13 +379,13 @@ def test_beambeam3d_bhabha_qss(test_context):
                                                                 capacity={
                                                                     "beamstrahlungtable": int(0),
                                                                     "bhabhatable": int(0),
-                                                                    "lumitable": int(n_slices*n_macroparticles_b1)
+                                                                    "lumitable": int(1)
                                                                 })
     record_qss_b2 = line_b2.start_internal_logging_for_elements_of_type(xf.BeamBeamBiGaussian3D, 
                                                                 capacity={
                                                                     "beamstrahlungtable": int(0),
                                                                     "bhabhatable": int(0),
-                                                                    "lumitable": int(n_slices*n_macroparticles_b2)
+                                                                    "lumitable": int(1)
                                                                 })
 
     multitracker.track(num_turns=1)
@@ -419,8 +403,8 @@ def test_beambeam3d_bhabha_qss(test_context):
     piwi    = sigma_z_tot / sigma_x * phi  # [1]
     lumi_ip = bunch_intensity**2 / (4*np.pi*sigma_x*np.sqrt(1 + piwi**2)*sigma_y)  # [m^-2] for 1 IP
 
-    lumi_qss_b1 = np.sum(record_qss_b1.lumitable.luminosity)
-    lumi_qss_b2 = np.sum(record_qss_b2.lumitable.luminosity)
+    lumi_qss_b1 = record_qss_b1.lumitable.luminosity[0]
+    lumi_qss_b2 = record_qss_b2.lumitable.luminosity[0]
     rel_err_qss_b1 = 100*(lumi_qss_b1 - lumi_ip) / lumi_ip
     rel_err_qss_b2 = 100*(lumi_qss_b2 - lumi_ip) / lumi_ip
     print("QSS beam 1:", lumi_qss_b1, rel_err_qss_b1, "[%]")
@@ -432,7 +416,7 @@ def test_beambeam3d_bhabha_qss(test_context):
 
 
 @for_all_test_contexts
-def test_beambeam3d_bhabha_ss(test_context):
+def test_beambeam3d_lumi_ss(test_context):
 
     if isinstance(test_context, xo.ContextPyopencl):
         pytest.skip("Not implemented for OpenCL")
@@ -565,15 +549,6 @@ def test_beambeam3d_bhabha_ss(test_context):
     line_b1.build_tracker(_context=test_context)
     line_b2.build_tracker(_context=test_context)
 
-    assert line_b1._needs_rng == False
-    assert line_b2._needs_rng == False
-
-    line_b1.configure_radiation(model_bhabha='quantum')
-    line_b2.configure_radiation(model_bhabha='quantum')
-
-    assert line_b1._needs_rng == True
-    assert line_b2._needs_rng == True
-
     particles_b1.name = "b1"
     particles_b2.name = "b2"
 
@@ -584,14 +559,14 @@ def test_beambeam3d_bhabha_ss(test_context):
     record_ss_b1 = line_b1.start_internal_logging_for_elements_of_type(xf.BeamBeamBiGaussian3D, 
                                                                 capacity={
                                                                     "beamstrahlungtable": int(0),
-                                                                    "bhabhatable": int(3e3),
-                                                                    "lumitable": int(n_slices*n_macroparticles_b1)
+                                                                    "bhabhatable": int(0),
+                                                                    "lumitable": int(1)
                                                                 })
     record_ss_b2 = line_b2.start_internal_logging_for_elements_of_type(xf.BeamBeamBiGaussian3D, 
                                                                 capacity={
                                                                     "beamstrahlungtable": int(0),
-                                                                    "bhabhatable": int(3e3),
-                                                                    "lumitable": int(n_slices*n_macroparticles_b2)
+                                                                    "bhabhatable": int(0),
+                                                                    "lumitable": int(1)
                                                                 })
 
     multitracker.track(num_turns=1)
@@ -609,8 +584,8 @@ def test_beambeam3d_bhabha_ss(test_context):
     piwi    = sigma_z_tot / sigma_x * phi  # [1] 
     lumi_ip = bunch_intensity**2 / (4*np.pi*sigma_x*np.sqrt(1 + piwi**2)*sigma_y)  # [m^-2] for 1 IP
 
-    lumi_ss_b1 = np.sum(record_ss_b1.lumitable.luminosity)
-    lumi_ss_b2 = np.sum(record_ss_b2.lumitable.luminosity)
+    lumi_ss_b1 = record_ss_b1.lumitable.luminosity[0]
+    lumi_ss_b2 = record_ss_b2.lumitable.luminosity[0]
     rel_err_ss_b1 = 100*(lumi_ss_b1 - lumi_ip) / lumi_ip
     rel_err_ss_b2 = 100*(lumi_ss_b2 - lumi_ip) / lumi_ip
     print("SS beam 1:", lumi_ss_b1, rel_err_ss_b1, "[%]")

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -70,7 +70,6 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
         'scale_strength': xo.Float64,
 
-        '_phi': xo.Float64,
         '_sin_phi': xo.Float64,
         '_cos_phi': xo.Float64,
         '_tan_phi': xo.Float64,
@@ -410,7 +409,6 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
         self.flag_crabwaist = flag_crabwaist
         self.k2_factor = k2_factor
-        self._phi = phi
 
         assert other_beam_q0 is not None
         self.other_beam_q0 = other_beam_q0

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -142,6 +142,7 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
          #crabwaist
          'flag_crabwaist': xo.Int64,
+         'k2_factor': xo.Float64,
     }
 
     _internal_record_class = BeamBeamBiGaussian3DRecord
@@ -210,6 +211,7 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
                     flag_luminosity=0,
 
                     flag_crabwaist=0,
+                    k2_factor=1.0,
 
                     slices_other_beam_x_center_star=None,
                     slices_other_beam_px_center_star=None,
@@ -407,6 +409,7 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
         self._init_luminosity(flag_luminosity)
 
         self.flag_crabwaist = flag_crabwaist
+        self.k2_factor = k2_factor
         self._phi = phi
 
         assert other_beam_q0 is not None

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -139,9 +139,6 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
          #lumi
          'flag_luminosity': xo.Int64,
 
-         #crabwaist
-         'flag_crabwaist': xo.Int64,
-         'k2_factor': xo.Float64,
     }
 
     _internal_record_class = BeamBeamBiGaussian3DRecord
@@ -208,9 +205,6 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
                     flag_beamsize_effect=1,
 
                     flag_luminosity=0,
-
-                    flag_crabwaist=0,
-                    k2_factor=1.0,
 
                     slices_other_beam_x_center_star=None,
                     slices_other_beam_px_center_star=None,
@@ -406,9 +400,6 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
         self._init_bhabha(flag_bhabha, compt_x_min, flag_beamsize_effect)
 
         self._init_luminosity(flag_luminosity)
-
-        self.flag_crabwaist = flag_crabwaist
-        self.k2_factor = k2_factor
 
         assert other_beam_q0 is not None
         self.other_beam_q0 = other_beam_q0

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -210,7 +210,6 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
                     flag_luminosity=0,
 
                     flag_crabwaist=0,
-                    _phi=0,
 
                     slices_other_beam_x_center_star=None,
                     slices_other_beam_px_center_star=None,
@@ -408,7 +407,7 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
         self._init_luminosity(flag_luminosity)
 
         self.flag_crabwaist = flag_crabwaist
-        self._phi = _phi
+        self._phi = phi
 
         assert other_beam_q0 is not None
         self.other_beam_q0 = other_beam_q0

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -70,6 +70,7 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
         'scale_strength': xo.Float64,
 
+        '_phi': xo.Float64,
         '_sin_phi': xo.Float64,
         '_cos_phi': xo.Float64,
         '_tan_phi': xo.Float64,
@@ -138,6 +139,9 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
          #lumi
          'flag_luminosity': xo.Int64,
+
+         #crabwaist
+         'flag_crabwaist': xo.Int64,
     }
 
     _internal_record_class = BeamBeamBiGaussian3DRecord
@@ -204,6 +208,9 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
                     flag_beamsize_effect=1,
 
                     flag_luminosity=0,
+
+                    flag_crabwaist=0,
+                    _phi=0,
 
                     slices_other_beam_x_center_star=None,
                     slices_other_beam_px_center_star=None,
@@ -399,6 +406,9 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
         self._init_bhabha(flag_bhabha, compt_x_min, flag_beamsize_effect)
 
         self._init_luminosity(flag_luminosity)
+
+        self.flag_crabwaist = flag_crabwaist
+        self._phi = _phi
 
         assert other_beam_q0 is not None
         self.other_beam_q0 = other_beam_q0

--- a/xfields/beam_elements/beambeam_src/beambeam3d.h
+++ b/xfields/beam_elements/beambeam_src/beambeam3d.h
@@ -360,7 +360,9 @@ void BeamBeamBiGaussian3D_track_local_particle(BeamBeamBiGaussian3DData el, Loca
         const int flag_crabwaist = BeamBeamBiGaussian3DData_get_flag_crabwaist(el);
         if (flag_crabwaist){
           double const phi = BeamBeamBiGaussian3DData_get__phi(el);
-          acw = -1.0/tan(2*phi);
+	  double const k2_factor = BeamBeamBiGaussian3DData_get_k2_factor(el);
+
+          acw = -k2_factor/tan(2*phi);
           px += 0.5 * acw * py*py;
           y  -= acw * x*py;
         }

--- a/xfields/beam_elements/beambeam_src/beambeam3d.h
+++ b/xfields/beam_elements/beambeam_src/beambeam3d.h
@@ -11,6 +11,149 @@
 #endif
 
 /*gpufun*/
+void do_luminosity(BeamBeamBiGaussian3DData el, LocalParticle *part,
+               double* rho, double* wgt,
+               double const x_bar_hat_star, double const y_bar_hat_star,
+               double const Sig_11_hat_star, double const Sig_33_hat_star,
+               double const num_part_slice){
+
+    // gaussian charge density: at x, y density given by the 2D gaussian, local lumi depending on x y, total lumi sum of all
+    get_charge_density(x_bar_hat_star, y_bar_hat_star, sqrt(Sig_11_hat_star), sqrt(Sig_33_hat_star), rho);
+    *wgt =  LocalParticle_get_weight(part) * num_part_slice * (*rho);  // [m^-2] integrated lumi of a single electron colliding with the opposing slice
+
+    // init record table
+    BeamBeamBiGaussian3DRecordData lumi_record = NULL;
+    LumiTableData lumi_table                   = NULL;
+    RecordIndex lumi_table_index               = NULL;
+    lumi_record = BeamBeamBiGaussian3DData_getp_internal_record(el, part);
+    if (lumi_record){
+        lumi_table       = BeamBeamBiGaussian3DRecordData_getp_lumitable(lumi_record);
+        lumi_table_index =                      LumiTableData_getp__index(lumi_table);
+
+    const int at_turn = LocalParticle_get_at_turn(part);
+    double* lumi_address = LumiTableData_getp1_luminosity(lumi_table, at_turn);  // double pointer
+    atomicAdd(lumi_address, *wgt);
+    }
+}
+
+/*gpufun*/
+void do_bhabha(BeamBeamBiGaussian3DData el, LocalParticle *part,
+               double* rho, double* wgt,
+               const int64_t flag_luminosity, double const q0,
+               double const x_bar_hat_star, double const y_bar_hat_star,
+               double const Sig_11_hat_star, double const Sig_33_hat_star,
+               double const num_part_slice, double const S,
+               double* px_star, double* py_star, double* pzeta_star,
+               double px_slice_star, double py_slice_star, double pzeta_slice_star){
+
+    // init record table
+    BeamBeamBiGaussian3DRecordData bhabha_record = NULL;
+    BhabhaTableData bhabha_table                 = NULL;
+    RecordIndex bhabha_table_index               = NULL;
+    bhabha_record = BeamBeamBiGaussian3DData_getp_internal_record(el, part);
+    if (bhabha_record){
+        bhabha_table       = BeamBeamBiGaussian3DRecordData_getp_bhabhatable(bhabha_record);
+        bhabha_table_index =                      BhabhaTableData_getp__index(bhabha_table);
+    }
+
+    // switch for beam size effect
+    const int64_t flag_beamsize_effect = BeamBeamBiGaussian3DData_get_flag_beamsize_effect(el);
+
+    // gaussian charge density, we are centered at the strong slice centroid
+    if (flag_luminosity != 1 && flag_beamsize_effect == 0){
+      get_charge_density(x_bar_hat_star, y_bar_hat_star, sqrt(Sig_11_hat_star), sqrt(Sig_33_hat_star), rho);
+      *wgt =  LocalParticle_get_weight(part) * num_part_slice * (*rho);  // [m^-2] integrated lumi of a single electron colliding with the opposing slice
+    }
+
+    LocalParticle_update_pzeta(part, *pzeta_star);  // update energy vars with boost and/or last kick
+
+    const double other_beam_slice_energy =  LocalParticle_get_energy0(part)*(1 + pzeta_slice_star) * 1e-9;  // [GeV] for now betastar is 1; later change to other beam E0
+
+    const double compt_x_min = BeamBeamBiGaussian3DData_get_compt_x_min(el);
+    int n_photons = requiv(part, other_beam_slice_energy, compt_x_min);  // generate virtual photons of the opposite slice using the average energy of the opposite slice
+
+    // generate virtual photons of the opposite slice
+    double xmin, e_photon, q2, one_m_x, x_photon, y_photon, px_photon, py_photon, pzeta_photon, radius, theta;
+    for (int i_phot=0; i_phot<n_photons; i_phot++){
+
+      mequiv(part, other_beam_slice_energy, compt_x_min, &xmin, &e_photon, &q2, &one_m_x);  // here again use opposite slice energy average
+
+      // apply beam size effect here (affects x and y only)
+      switch(flag_beamsize_effect){
+      case 0:  // this is w.r.t of the strong slice centroid
+          radius = 0.0;
+          x_photon = x_bar_hat_star;
+          y_photon = y_bar_hat_star;
+          break;
+      case 1:  // photons distributed on a disc around centroid
+          radius = HBAR_GEVS*C_LIGHT / sqrt(q2*one_m_x);  // [m]
+          //printf("radius: %.6e\n", radius);
+          radius = min(radius, 1e5);
+          x_photon = x_bar_hat_star + rndm_sincos(part, &theta) * radius;
+          y_photon = y_bar_hat_star + theta * radius;
+
+          // resample charge density at randomized photon location
+          get_charge_density(x_photon, y_photon, sqrt(Sig_11_hat_star), sqrt(Sig_33_hat_star), rho);
+          *wgt =  LocalParticle_get_weight(part) * num_part_slice * (*rho);  // [m^-2] integrated lumi of a single electron colliding with the opposing slice
+          break;
+      }
+
+      // virtual photons are located at the opposite slice centroid
+
+      px_photon = px_slice_star;
+      py_photon = py_slice_star;
+      pzeta_photon = pzeta_slice_star;
+
+      //if (radius < sqrt(Sig_33_hat_star)){
+        // for each virtual photon get compton scatterings; updates pzeta and energy vars inside
+        compt_do(part, bhabha_record, bhabha_table_index, bhabha_table,
+                 e_photon, compt_x_min, q2,
+                 x_photon, y_photon, S, px_photon, py_photon, pzeta_photon,
+                 *wgt, px_star, py_star, pzeta_star, q0);
+
+        // reload pzeta since they changed from compton; px and py are changed only locally
+        *pzeta_star = LocalParticle_get_pzeta(part);  // bhabha rescales energy vars, so load again before kick
+     // }
+    }
+}
+
+
+/*gpufun*/
+void do_beamstrahlung(BeamBeamBiGaussian3DData el, LocalParticle *part,
+                      double Fx_star, double Fy_star,
+                      double* pzeta_star, const int i_slice, double const num_part_slice,
+                      const int64_t flag_beamstrahlung){
+
+        // init record table
+        BeamBeamBiGaussian3DRecordData beamstrahlung_record = NULL;
+        BeamstrahlungTableData beamstrahlung_table          = NULL;
+        RecordIndex beamstrahlung_table_index               = NULL;
+        beamstrahlung_record = BeamBeamBiGaussian3DData_getp_internal_record(el, part);
+        if (beamstrahlung_record){
+            beamstrahlung_table       = BeamBeamBiGaussian3DRecordData_getp_beamstrahlungtable(beamstrahlung_record);
+            beamstrahlung_table_index =                      BeamstrahlungTableData_getp__index(beamstrahlung_table);
+        }
+
+        LocalParticle_update_pzeta(part, *pzeta_star);  // update energy vars with boost and/or last kick
+        if(flag_beamstrahlung==1){
+
+            // get unboosted strong slice RMS [m]
+            double sqrtSigma_11 = BeamBeamBiGaussian3DData_get_slices_other_beam_sqrtSigma_11_beamstrahlung(el, i_slice);
+            double sqrtSigma_33 = BeamBeamBiGaussian3DData_get_slices_other_beam_sqrtSigma_33_beamstrahlung(el, i_slice);
+            double sqrtSigma_55 = BeamBeamBiGaussian3DData_get_slices_other_beam_sqrtSigma_55_beamstrahlung(el, i_slice);
+            beamstrahlung_avg(part, beamstrahlung_record, beamstrahlung_table_index, beamstrahlung_table,
+                num_part_slice, sqrtSigma_11, sqrtSigma_33, sqrtSigma_55);
+        } else if (flag_beamstrahlung==2){
+            double const Fr = hypot(Fx_star, Fy_star) * LocalParticle_get_rpp(part); // radial kick [1]
+            double const dz = .5*BeamBeamBiGaussian3DData_get_slices_other_beam_zeta_bin_width_star_beamstrahlung(el, i_slice);  // half slice width [m]
+            beamstrahlung(part, beamstrahlung_record, beamstrahlung_table_index, beamstrahlung_table, Fr, dz);
+        }
+        *pzeta_star = LocalParticle_get_pzeta(part);  // BS rescales energy vars, so load again before kick
+    }
+
+
+
+/*gpufun*/
 void synchrobeam_kick(
         BeamBeamBiGaussian3DData el, LocalParticle *part,
         const int i_slice,
@@ -132,100 +275,19 @@ void synchrobeam_kick(
     // calculate luminosity
     const int64_t flag_luminosity = BeamBeamBiGaussian3DData_get_flag_luminosity(el);
     if (flag_luminosity == 1){
-
-        // gaussian charge density: at x, y density given by the 2D gaussian, local lumi depending on x y, total lumi sum of all
-        get_charge_density(x_bar_hat_star, y_bar_hat_star, sqrt(Sig_11_hat_star), sqrt(Sig_33_hat_star), &rho);
-        wgt =  LocalParticle_get_weight(part) * num_part_slice * rho;  // [m^-2] integrated lumi of a single electron colliding with the opposing slice
-
-        // init record table
-        BeamBeamBiGaussian3DRecordData lumi_record = NULL;
-        LumiTableData lumi_table                   = NULL;
-        RecordIndex lumi_table_index               = NULL;
-        lumi_record = BeamBeamBiGaussian3DData_getp_internal_record(el, part);
-        if (lumi_record){
-            lumi_table       = BeamBeamBiGaussian3DRecordData_getp_lumitable(lumi_record);
-            lumi_table_index =                      LumiTableData_getp__index(lumi_table);
-
-        const int at_turn = LocalParticle_get_at_turn(part);
-        double* lumi_address = LumiTableData_getp1_luminosity(lumi_table, at_turn);  // double pointer
-        atomicAdd(lumi_address, wgt);
-        }
+        do_luminosity(el, part, &rho, &wgt,
+            x_bar_hat_star, y_bar_hat_star, Sig_11_hat_star, Sig_33_hat_star,
+            num_part_slice);
     }
 
     // emit bhabha photons from single macropart
     #ifndef XFIELDS_BB3D_NO_BHABHA
     const int64_t flag_bhabha = BeamBeamBiGaussian3DData_get_flag_bhabha(el);
     if (flag_bhabha == 1) {
-
-        // init record table
-        BeamBeamBiGaussian3DRecordData bhabha_record = NULL;
-        BhabhaTableData bhabha_table                 = NULL;
-        RecordIndex bhabha_table_index               = NULL;
-        bhabha_record = BeamBeamBiGaussian3DData_getp_internal_record(el, part);
-        if (bhabha_record){
-            bhabha_table       = BeamBeamBiGaussian3DRecordData_getp_bhabhatable(bhabha_record);
-            bhabha_table_index =                      BhabhaTableData_getp__index(bhabha_table);
-        }
-
-        // switch for beam size effect
-        const int64_t flag_beamsize_effect = BeamBeamBiGaussian3DData_get_flag_beamsize_effect(el);
-
-        // gaussian charge density, we are centered at the strong slice centroid
-        if (flag_luminosity != 1 && flag_beamsize_effect == 0){
-          get_charge_density(x_bar_hat_star, y_bar_hat_star, sqrt(Sig_11_hat_star), sqrt(Sig_33_hat_star), &rho);
-          wgt =  LocalParticle_get_weight(part) * num_part_slice * rho;  // [m^-2] integrated lumi of a single electron colliding with the opposing slice
-        }
-
-        LocalParticle_update_pzeta(part, *pzeta_star);  // update energy vars with boost and/or last kick
-    
-        const double other_beam_slice_energy =  LocalParticle_get_energy0(part)*(1 + pzeta_slice_star) * 1e-9;  // [GeV] for now betastar is 1; later change to other beam E0    
-
-        const double compt_x_min = BeamBeamBiGaussian3DData_get_compt_x_min(el);
-        int n_photons = requiv(part, other_beam_slice_energy, compt_x_min);  // generate virtual photons of the opposite slice using the average energy of the opposite slice
-    
-        // generate virtual photons of the opposite slice
-        double xmin, e_photon, q2, one_m_x, x_photon, y_photon, px_photon, py_photon, pzeta_photon, radius, theta;
-        for (int i_phot=0; i_phot<n_photons; i_phot++){
-    
-          mequiv(part, other_beam_slice_energy, compt_x_min, &xmin, &e_photon, &q2, &one_m_x);  // here again use opposite slice energy average
-    
-          // apply beam size effect here (affects x and y only)
-          switch(flag_beamsize_effect){
-          case 0:  // this is w.r.t of the strong slice centroid
-              radius = 0.0;
-              x_photon = x_bar_hat_star;
-              y_photon = y_bar_hat_star;
-              break;
-          case 1:  // photons distributed on a disc around centroid
-              radius = HBAR_GEVS*C_LIGHT / sqrt(q2*one_m_x);  // [m]
-              //printf("radius: %.6e\n", radius);
-              radius = min(radius, 1e5);
-              x_photon = x_bar_hat_star + rndm_sincos(part, &theta) * radius;
-              y_photon = y_bar_hat_star + theta * radius;
-
-              // resample charge density at randomized photon location
-              get_charge_density(x_photon, y_photon, sqrt(Sig_11_hat_star), sqrt(Sig_33_hat_star), &rho);
-              wgt =  LocalParticle_get_weight(part) * num_part_slice * rho;  // [m^-2] integrated lumi of a single electron colliding with the opposing slice
-              break;
-          }
-
-          // virtual photons are located at the opposite slice centroid
-
-          px_photon = px_slice_star;
-          py_photon = py_slice_star; 
-          pzeta_photon = pzeta_slice_star;
-          
-          //if (radius < sqrt(Sig_33_hat_star)){
-            // for each virtual photon get compton scatterings; updates pzeta and energy vars inside
-            compt_do(part, bhabha_record, bhabha_table_index, bhabha_table,
-                     e_photon, compt_x_min, q2, 
-                     x_photon, y_photon, S, px_photon, py_photon, pzeta_photon, 
-                     wgt, px_star, py_star, pzeta_star, q0);
-    
-            // reload pzeta since they changed from compton; px and py are changed only locally
-            *pzeta_star = LocalParticle_get_pzeta(part);  // bhabha rescales energy vars, so load again before kick
-         // }
-        }
+        do_bhabha(el, part, &rho, &wgt, flag_luminosity, q0,
+            x_bar_hat_star, y_bar_hat_star, Sig_11_hat_star, Sig_33_hat_star,
+            num_part_slice, S, px_star, py_star, pzeta_star,
+            px_slice_star, py_slice_star, pzeta_slice_star);
     }
     #endif
 
@@ -233,32 +295,8 @@ void synchrobeam_kick(
     #ifndef XFIELDS_BB3D_NO_BEAMSTR
     const int64_t flag_beamstrahlung = BeamBeamBiGaussian3DData_get_flag_beamstrahlung(el);
     if(flag_beamstrahlung!=0){
-
-        // init record table
-        BeamBeamBiGaussian3DRecordData beamstrahlung_record = NULL;
-        BeamstrahlungTableData beamstrahlung_table          = NULL;
-        RecordIndex beamstrahlung_table_index               = NULL;
-        beamstrahlung_record = BeamBeamBiGaussian3DData_getp_internal_record(el, part);
-        if (beamstrahlung_record){
-            beamstrahlung_table       = BeamBeamBiGaussian3DRecordData_getp_beamstrahlungtable(beamstrahlung_record);
-            beamstrahlung_table_index =                      BeamstrahlungTableData_getp__index(beamstrahlung_table);
-        }
-
-        LocalParticle_update_pzeta(part, *pzeta_star);  // update energy vars with boost and/or last kick
-        if(flag_beamstrahlung==1){
-
-            // get unboosted strong slice RMS [m]
-            double sqrtSigma_11 = BeamBeamBiGaussian3DData_get_slices_other_beam_sqrtSigma_11_beamstrahlung(el, i_slice);
-            double sqrtSigma_33 = BeamBeamBiGaussian3DData_get_slices_other_beam_sqrtSigma_33_beamstrahlung(el, i_slice);
-            double sqrtSigma_55 = BeamBeamBiGaussian3DData_get_slices_other_beam_sqrtSigma_55_beamstrahlung(el, i_slice);
-            beamstrahlung_avg(part, beamstrahlung_record, beamstrahlung_table_index, beamstrahlung_table,
-                num_part_slice, sqrtSigma_11, sqrtSigma_33, sqrtSigma_55); 
-        } else if (flag_beamstrahlung==2){
-            double const Fr = hypot(Fx_star, Fy_star) * LocalParticle_get_rpp(part); // radial kick [1]
-            double const dz = .5*BeamBeamBiGaussian3DData_get_slices_other_beam_zeta_bin_width_star_beamstrahlung(el, i_slice);  // half slice width [m]
-            beamstrahlung(part, beamstrahlung_record, beamstrahlung_table_index, beamstrahlung_table, Fr, dz);
-        }
-        *pzeta_star = LocalParticle_get_pzeta(part);  // BS rescales energy vars, so load again before kick
+        do_beamstrahlung(el, part, Fx_star, Fy_star, pzeta_star,
+           i_slice, num_part_slice, flag_beamstrahlung);
     }
     #endif
 
@@ -271,6 +309,7 @@ void synchrobeam_kick(
     *y_star = *y_star - S*Fy_star;
     *py_star = *py_star + Fy_star;
 }
+
 
 /*gpufun*/
 void BeamBeamBiGaussian3D_track_local_particle(BeamBeamBiGaussian3DData el, LocalParticle* part0){

--- a/xfields/beam_elements/beambeam_src/beambeam3d.h
+++ b/xfields/beam_elements/beambeam_src/beambeam3d.h
@@ -361,7 +361,7 @@ void BeamBeamBiGaussian3D_track_local_particle(BeamBeamBiGaussian3DData el, Loca
         if (flag_crabwaist){
 	  double const k2_factor = BeamBeamBiGaussian3DData_get_k2_factor(el);
 
-          double tan_2phi = 2.0*tan_phi / (1.0 - tan_phi*tan_phi)  // trig id
+          double tan_2phi = 2.0*tan_phi / (1.0 - tan_phi*tan_phi);  // trig id
           acw = -k2_factor/tan_2phi;
           px += 0.5 * acw * py*py;
           y  -= acw * x*py;

--- a/xfields/beam_elements/beambeam_src/beambeam3d.h
+++ b/xfields/beam_elements/beambeam_src/beambeam3d.h
@@ -355,18 +355,6 @@ void BeamBeamBiGaussian3D_track_local_particle(BeamBeamBiGaussian3DData el, Loca
         const double q0 = LocalParticle_get_q0(part);
         const double p0c = LocalParticle_get_p0c(part); // eV
 
-        // crabwaist here
-        double acw;
-        const int flag_crabwaist = BeamBeamBiGaussian3DData_get_flag_crabwaist(el);
-        if (flag_crabwaist){
-	  double const k2_factor = BeamBeamBiGaussian3DData_get_k2_factor(el);
-
-          double tan_2phi = 2.0*tan_phi / (1.0 - tan_phi*tan_phi);  // trig id
-          acw = -k2_factor/tan_2phi;
-          px += 0.5 * acw * py*py;
-          y  -= acw * x*py;
-        }
-
         // Change reference frame
         change_ref_frame_coordinates(
             &x, &px, &y, &py, &zeta, &pzeta,
@@ -395,12 +383,6 @@ void BeamBeamBiGaussian3D_track_local_particle(BeamBeamBiGaussian3DData el, Loca
             post_subtract_y, post_subtract_py,
             post_subtract_zeta, post_subtract_pzeta,
             sin_phi, cos_phi, tan_phi, sin_alpha, cos_alpha);
-
-        // de-crabwaist here
-        if (flag_crabwaist){
-          px -= 0.5 * acw * py*py;
-          y  += acw * x*py;
-        }
 
         // Store
         LocalParticle_set_x(part, x);

--- a/xfields/beam_elements/beambeam_src/beambeam3d.h
+++ b/xfields/beam_elements/beambeam_src/beambeam3d.h
@@ -316,6 +316,16 @@ void BeamBeamBiGaussian3D_track_local_particle(BeamBeamBiGaussian3DData el, Loca
         const double q0 = LocalParticle_get_q0(part);
         const double p0c = LocalParticle_get_p0c(part); // eV
 
+        // crabwaist here
+        double acw;
+        const int flag_crabwaist = BeamBeamBiGaussian3DData_get_flag_crabwaist(el);
+        if (flag_crabwaist){
+          double const phi = BeamBeamBiGaussian3DData_get__phi(el);
+          acw = -1.0/tan(2*phi);
+          px += 0.5 * acw * py*py;
+          y  -= acw * x*py;
+        }
+
         // Change reference frame
         change_ref_frame_coordinates(
             &x, &px, &y, &py, &zeta, &pzeta,
@@ -344,6 +354,12 @@ void BeamBeamBiGaussian3D_track_local_particle(BeamBeamBiGaussian3DData el, Loca
             post_subtract_y, post_subtract_py,
             post_subtract_zeta, post_subtract_pzeta,
             sin_phi, cos_phi, tan_phi, sin_alpha, cos_alpha);
+
+        // de-crabwaist here
+        if (flag_crabwaist){
+          px -= 0.5 * acw * py*py;
+          y  += acw * x*py;
+        }
 
         // Store
         LocalParticle_set_x(part, x);

--- a/xfields/beam_elements/beambeam_src/beambeam3d.h
+++ b/xfields/beam_elements/beambeam_src/beambeam3d.h
@@ -359,10 +359,10 @@ void BeamBeamBiGaussian3D_track_local_particle(BeamBeamBiGaussian3DData el, Loca
         double acw;
         const int flag_crabwaist = BeamBeamBiGaussian3DData_get_flag_crabwaist(el);
         if (flag_crabwaist){
-          double const phi = BeamBeamBiGaussian3DData_get__phi(el);
 	  double const k2_factor = BeamBeamBiGaussian3DData_get_k2_factor(el);
 
-          acw = -k2_factor/tan(2*phi);
+          double tan_2phi = 2.0*tan_phi / (1.0 - tan_phi*tan_phi)  // trig id
+          acw = -k2_factor/tan_2phi;
           px += 0.5 * acw * py*py;
           y  -= acw * x*py;
         }

--- a/xfields/beam_elements/beambeam_src/beambeam3d_methods_for_strongstrong.h
+++ b/xfields/beam_elements/beambeam_src/beambeam3d_methods_for_strongstrong.h
@@ -40,18 +40,6 @@ void BeamBeamBiGaussian3D_change_ref_frame_local_particle(
         double zeta = LocalParticle_get_zeta(part);
         double pzeta = LocalParticle_get_pzeta(part);
 
-
-        // crabwaist
-        double acw;
-        const int flag_crabwaist = BeamBeamBiGaussian3DData_get_flag_crabwaist(el);
-        if (flag_crabwaist){
-          double const k2_factor = BeamBeamBiGaussian3DData_get_k2_factor(el);
-          double tan_2phi = 2.0*tan_phi / (1.0 - tan_phi*tan_phi);  // trig id
-          acw = -k2_factor/tan_2phi;
-          px += 0.5 * acw * py*py;
-          y  -= acw * x*py;
-        }
-
         // Change reference frame
         change_ref_frame_coordinates(
             &x, &px, &y, &py, &zeta, &pzeta,
@@ -117,17 +105,6 @@ void BeamBeamBiGaussian3D_change_back_ref_frame_and_subtract_dipolar_local_parti
             post_subtract_y, post_subtract_py,
             post_subtract_zeta, post_subtract_pzeta,
             sin_phi, cos_phi, tan_phi, sin_alpha, cos_alpha);
-
-        // de-crabwaist here 
-        double acw;
-        const int flag_crabwaist = BeamBeamBiGaussian3DData_get_flag_crabwaist(el);
-        if (flag_crabwaist){
-          double const k2_factor = BeamBeamBiGaussian3DData_get_k2_factor(el);
-          double tan_2phi = 2.0*tan_phi / (1.0 - tan_phi*tan_phi);  // trig id
-          acw = -k2_factor/tan_2phi;
-          px -= 0.5 * acw * py*py;
-          y  += acw * x*py;
-        }
 
         // Store
         LocalParticle_set_x(part, x);


### PR DESCRIPTION
- in beambeam3d.h separated the above 3 functions
- update test_lumi.py where now the luminosity buffer has a size equivalent to the number of turns instead of the number of particles * number of slices

