### PR TITLE
Fix/spch fcontiguous

### DIFF
--- a/xfields/solvers/fftsolvers.py
+++ b/xfields/solvers/fftsolvers.py
@@ -124,11 +124,10 @@ class FFTSolver3D(Solver):
         _workspace_dev.T[:self.nz, :self.ny, :self.nx] = rho.T
         self.fftplan.transform(_workspace_dev) # rho_rep_hat
 
-        # try:
-        #     _workspace_dev.T[:,:,:] *= (
-        #                 self._gint_rep_transf_dev.T) # phi_rep_hat
-        # except Exception: # pyopencl does not support array broadcasting (used in 2.5D)
-        if True:
+        try:
+            _workspace_dev.T[:,:,:] *= (
+                        self._gint_rep_transf_dev.T) # phi_rep_hat
+        except Exception: # pyopencl does not support array broadcasting (used in 2.5D)
             # Check F-contiguity
             assert _workspace_dev.strides[0] == 16
             assert self._gint_rep_transf_dev.strides[0] == 16

--- a/xfields/solvers/fftsolvers.py
+++ b/xfields/solvers/fftsolvers.py
@@ -124,10 +124,15 @@ class FFTSolver3D(Solver):
         _workspace_dev.T[:self.nz, :self.ny, :self.nx] = rho.T
         self.fftplan.transform(_workspace_dev) # rho_rep_hat
 
-        try:
-            _workspace_dev.T[:,:,:] *= (
-                        self._gint_rep_transf_dev.T) # phi_rep_hat
-        except Exception: # pyopencl does not support array broadcasting (used in 2.5D)
+        # try:
+        #     _workspace_dev.T[:,:,:] *= (
+        #                 self._gint_rep_transf_dev.T) # phi_rep_hat
+        # except Exception: # pyopencl does not support array broadcasting (used in 2.5D)
+        if True:
+            # Check F-contiguity
+            assert _workspace_dev.strides[0] == 16
+            assert self._gint_rep_transf_dev.strides[0] == 16
+
             for ii in range(self.nz):
                 _workspace_dev.T[ii,:,:] *= (
                         self._gint_rep_transf_dev.T[0, :, :]) # phi_rep_hat
@@ -192,7 +197,9 @@ class FFTSolver2p5D(FFTSolver3D):
             del(temp_dev)
 
         # Transform the green function
-        gint_rep_transf = np.fft.fftn(gint_rep, axes=(0,1))
+        gint_rep_transf = np.zeros((2*nx, 2*ny),
+                           dtype=np.complex128, order='F')
+        gint_rep_transf[:, :] = np.fft.fftn(gint_rep, axes=(0,1))
 
         # Transfer to GPU (if needed)
         gint_rep_transf_dev = context.nparray_to_context_array(
@@ -247,7 +254,9 @@ class FFTSolver2p5DAveraged(Solver):
             del(temp_dev)
 
         # Transform the green function
-        gint_rep_transf = np.fft.fftn(gint_rep, axes=(0,1))
+        gint_rep_transf = np.zeros((2*nx, 2*ny),
+                           dtype=np.complex128, order='F')
+        gint_rep_transf[:, :] = np.fft.fftn(gint_rep, axes=(0,1))
 
         # Transfer to GPU (if needed)
         gint_rep_transf_dev = context.nparray_to_context_array(


### PR DESCRIPTION
**Changes:**
 - In 2.5D spacecharge models ensure that stored green function matrix is F-contiguous (in numpy 2.0 the FFT of a F-contifuous matrix is C-contiguous).