### PR TITLE
PIC beamstrahlung and alpha, phi setter

### DIFF
--- a/tests/test_alpha_pi_setter.py
+++ b/tests/test_alpha_pi_setter.py
@@ -1,0 +1,158 @@
+import pathlib
+import pytest
+
+import numpy as np
+from scipy import constants as cst
+
+import xobjects as xo
+import xtrack as xt
+import xfields as xf
+import xpart as xp
+
+import itertools
+
+from xobjects.test_helpers import for_all_test_contexts
+
+@for_all_test_contexts(excluding="ContextPyopencl")
+def test_beambeam3d_lumi_ws_no_config(test_context):
+
+    if isinstance(test_context, xo.ContextCupy):
+        import cupy as cp
+
+    print(repr(test_context))
+
+    n_slices = 100
+    phi = 0
+    alpha = 0
+    slicer = xf.TempSlicer(n_slices=100, sigma_z=1e-3, mode="shatilov")
+
+    bbeam = xf.BeamBeamBiGaussian3D(
+        other_beam_q0       = -1,
+        phi                 = phi,
+        alpha               = alpha,
+        config_for_update   = None,
+        # slice intensity [num. real particles] 101 inferred from length of this
+        slices_other_beam_num_particles = slicer.bin_weights * 1e10,
+        # unboosted strong beam moments
+        slices_other_beam_zeta_center   = slicer.bin_centers,
+        slices_other_beam_Sigma_11      = n_slices * [1e-6],
+        slices_other_beam_Sigma_22      = n_slices * [1e-9],
+        slices_other_beam_Sigma_33      = n_slices * [1e-7],
+        slices_other_beam_Sigma_44      = n_slices * [1e-8],
+        # only if BS on
+        slices_other_beam_zeta_bin_width_star_beamstrahlung = \
+        slicer.bin_widths_beamstrahlung / np.cos(phi),  # boosted dz
+        # has to be set
+        slices_other_beam_Sigma_12      = n_slices * [0],
+        slices_other_beam_Sigma_34      = n_slices * [0],
+    )
+
+    #########
+    # tests #
+    #########
+
+    phi_arr = np.hstack([0, np.logspace(-7, 0, 11), 0])
+    alpha_arr = np.hstack([np.arange(9)*np.pi/4, 0])
+    grid = itertools.product(phi_arr, alpha_arr)
+
+    for phi_i, alpha_i in grid:
+        bbeam.phi = phi_i
+        bbeam.alpha = alpha_i
+        run_asserts(bbeam)
+
+# deferred expr. from beambeam3d.py
+def run_asserts(el, rtol=1e-14):
+    
+    assert np.allclose(np.sin(el.alpha), el.sin_alpha, rtol=rtol)
+    assert np.allclose(np.cos(el.alpha), el.cos_alpha, rtol=rtol)
+    
+    assert np.allclose(np.sin(el.phi),  el.sin_phi, rtol=rtol)
+    assert np.allclose(np.cos(el.phi),  el.cos_phi, rtol=rtol)
+    assert np.allclose(np.tan(el.phi),  el.tan_phi, rtol=rtol)
+    
+    (
+    x_slices_star,
+    px_slices_star,
+    y_slices_star,
+    py_slices_star,
+    zeta_slices_star,
+    pzeta_slices_star,
+    ) = _python_boost(
+        x=el.slices_other_beam_x_center,
+        px=el.slices_other_beam_px_center,
+        y=el.slices_other_beam_y_center,
+        py=el.slices_other_beam_py_center,
+        zeta=el.slices_other_beam_zeta_center,
+        pzeta=el.slices_other_beam_pzeta_center,
+        sphi=el.sin_phi,
+        cphi=el.cos_phi,
+        tphi=el.tan_phi,
+        salpha=el.sin_alpha,
+        calpha=el.cos_alpha,
+    )
+
+    assert np.allclose(x_slices_star    ,     el.slices_other_beam_x_center_star, rtol=rtol)
+    assert np.allclose(px_slices_star   ,    el.slices_other_beam_px_center_star, rtol=rtol)
+    assert np.allclose(y_slices_star    ,     el.slices_other_beam_y_center_star, rtol=rtol)
+    assert np.allclose(py_slices_star   ,    el.slices_other_beam_py_center_star, rtol=rtol)
+    assert np.allclose(zeta_slices_star ,  el.slices_other_beam_zeta_center_star, rtol=rtol)
+    assert np.allclose(pzeta_slices_star, el.slices_other_beam_pzeta_center_star, rtol=rtol)
+    
+    assert np.all(el.slices_other_beam_Sigma_11                      == el.slices_other_beam_Sigma_11_star)
+    assert np.all(el.slices_other_beam_Sigma_12 / np.cos(el.phi)     == el.slices_other_beam_Sigma_12_star)
+    assert np.all(el.slices_other_beam_Sigma_13                      == el.slices_other_beam_Sigma_13_star)
+    assert np.all(el.slices_other_beam_Sigma_14 / np.cos(el.phi)     == el.slices_other_beam_Sigma_14_star)
+    assert np.all(el.slices_other_beam_Sigma_22 / np.cos(el.phi)**2  == el.slices_other_beam_Sigma_22_star)
+    assert np.all(el.slices_other_beam_Sigma_23 / np.cos(el.phi)     == el.slices_other_beam_Sigma_23_star)
+    assert np.all(el.slices_other_beam_Sigma_24 / np.cos(el.phi)**2  == el.slices_other_beam_Sigma_24_star)
+    assert np.all(el.slices_other_beam_Sigma_33                      == el.slices_other_beam_Sigma_33_star)
+    assert np.all(el.slices_other_beam_Sigma_34  / np.cos(el.phi)    == el.slices_other_beam_Sigma_34_star)
+    assert np.all(el.slices_other_beam_Sigma_44  / np.cos(el.phi)**2 == el.slices_other_beam_Sigma_44_star)
+    
+    assert np.all(el.slices_other_beam_zeta_bin_width_star_beamstrahlung ==\
+                  el.slices_other_beam_zeta_bin_width_beamstrahlung/np.cos(el.phi))
+    
+    
+def _python_boost_scalar(x, px, y, py, zeta, pzeta,
+                  sphi, cphi, tphi, salpha, calpha):
+
+    h = (
+        pzeta
+        + 1.0
+        - np.sqrt((1.0 + pzeta) * (1.0 + pzeta) - px * px - py * py)
+    )
+
+    px_st = px / cphi - h * calpha * tphi / cphi
+    py_st = py / cphi - h * salpha * tphi / cphi
+    pzeta_st = (
+        pzeta - px * calpha * tphi - py * salpha * tphi + h * tphi * tphi
+    )
+
+    pz_st = np.sqrt(
+        (1.0 + pzeta_st) * (1.0 + pzeta_st) - px_st * px_st - py_st * py_st
+    )
+    hx_st = px_st / pz_st
+    hy_st = py_st / pz_st
+    hzeta_st = 1.0 - (pzeta_st + 1) / pz_st
+
+    L11 = 1.0 + hx_st * calpha * sphi
+    L12 = hx_st * salpha * sphi
+    L13 = calpha * tphi
+
+    L21 = hy_st * calpha * sphi
+    L22 = 1.0 + hy_st * salpha * sphi
+    L23 = salpha * tphi
+
+    L31 = hzeta_st * calpha * sphi
+    L32 = hzeta_st * salpha * sphi
+    L33 = 1.0 / cphi
+
+    x_st = L11 * x + L12 * y + L13 * zeta
+    y_st = L21 * x + L22 * y + L23 * zeta
+    zeta_st = L31 * x + L32 * y + L33 * zeta
+
+    return x_st, px_st, y_st, py_st, zeta_st, pzeta_st
+
+_python_boost = np.vectorize(_python_boost_scalar,
+    excluded=("sphi", "cphi", "tphi", "salpha", "calpha"))
+

--- a/tests/test_beamstrahlung_pic.py
+++ b/tests/test_beamstrahlung_pic.py
@@ -1,0 +1,230 @@
+import pathlib
+import pytest
+
+import numpy as np
+from scipy import constants as cst
+
+import xobjects as xo
+import xtrack as xt
+import xfields as xf
+import xpart as xp
+
+from xobjects.test_helpers import for_all_test_contexts
+
+test_data_folder = pathlib.Path(
+    __file__).parent.joinpath('../test_data').absolute()
+
+@for_all_test_contexts(excluding="ContextPyopencl")
+def test_beambeam3d_beamstrahlung_pic(test_context):
+
+    if isinstance(test_context, xo.ContextCupy):
+        print(f"[test.py] default_blocksize: {test_context.default_block_size}")
+        import cupy as cp
+
+    print(repr(test_context))
+
+    # fcc ttbar 4 IP
+    bunch_intensity     =  1.55e11  # [e]
+    energy              =  182.5  # [GeV]
+    p0c                 =  182.5e9  # [eV]
+    mass0               =  511000  # [eV]
+    phi                 =  15e-3  # [rad] half xing
+    physemit_x          =  1.59e-09  # [m]
+    physemit_y          =  9e-13  # [m]
+    beta_x              =  1  # [m]
+    beta_y              =  1.6e-3  # [m]
+    sigma_x             =  np.sqrt(physemit_x*beta_x)  # [m]
+    sigma_px            =  np.sqrt(physemit_x/beta_x)  # [1]
+    sigma_y             =  np.sqrt(physemit_y*beta_y)  # [m]
+    sigma_py            =  np.sqrt(physemit_y/beta_y)  # [1]
+    sigma_z_tot         =  21.7e-4  # [m] sr+bs
+    sigma_delta_tot     =  19.2e-4  # [1] sr+bs
+    n_ip                =  4  # [1]
+    
+    n_macroparticles_b1 = int(1e6)
+    n_macroparticles_b2 = int(1e6)
+    
+    ################
+    # create beams #
+    ################
+    
+    #e-
+    particles_b1_pic = xp.Particles(
+                _context = test_context, 
+                q0        = -1,
+                p0c       = p0c,
+                mass0     = mass0,
+                x         = sigma_x        *np.random.randn(n_macroparticles_b1),
+                y         = sigma_y        *np.random.randn(n_macroparticles_b1),
+                zeta      = sigma_z_tot    *np.random.randn(n_macroparticles_b1),
+                px        = sigma_px       *np.random.randn(n_macroparticles_b1),
+                py        = sigma_py       *np.random.randn(n_macroparticles_b1),
+                delta     = sigma_delta_tot*np.random.randn(n_macroparticles_b1),
+                weight=bunch_intensity/n_macroparticles_b1
+                )
+    
+    # e+
+    particles_b2_pic = xp.Particles(
+                _context = test_context, 
+                q0        = 1,
+                p0c       = p0c,
+                mass0     = mass0,
+                x         = sigma_x        *np.random.randn(n_macroparticles_b2),
+                y         = sigma_y        *np.random.randn(n_macroparticles_b2),
+                zeta      = sigma_z_tot    *np.random.randn(n_macroparticles_b2),
+                px        = sigma_px       *np.random.randn(n_macroparticles_b2),
+                py        = sigma_py       *np.random.randn(n_macroparticles_b2),
+                delta     = sigma_delta_tot*np.random.randn(n_macroparticles_b2),
+                weight=bunch_intensity/n_macroparticles_b2
+                )
+    
+    ####################
+    # specify PIC grid #
+    ####################
+    
+    n_slices = 100    
+
+    x_lim_grid = 6 * sigma_x
+    y_lim_grid = 6 * sigma_y
+    z_lim_grid = 6 * sigma_z_tot
+    
+    bbpic_ip1_b1 = xf.BeamBeamPIC3D(
+        _context=test_context,
+            phi=phi, alpha=0,
+            x_range=(-x_lim_grid, x_lim_grid), dx=2*x_lim_grid/(n_slices),
+            y_range=(-y_lim_grid, y_lim_grid), dy=2*y_lim_grid/(n_slices),
+            z_range=(-z_lim_grid, z_lim_grid), dz=2*z_lim_grid/(n_slices),
+            )
+    
+    bbpic_ip1_b2 = xf.BeamBeamPIC3D(
+        _context=test_context,
+            phi=-phi, alpha=0,
+            x_range=(-x_lim_grid, x_lim_grid), dx=2*x_lim_grid/(n_slices),
+            y_range=(-y_lim_grid, y_lim_grid), dy=2*y_lim_grid/(n_slices),
+            z_range=(-z_lim_grid, z_lim_grid), dz=2*z_lim_grid/(n_slices),
+            )
+    
+    #######################
+    # set up communicator #
+    #######################
+    
+    pipeline_manager = xt.PipelineManager()
+    pipeline_manager.add_particles('p_b1', rank=0)
+    pipeline_manager.add_particles('p_b2', rank=0)
+    
+    pipeline_manager.add_element('IP1')
+    bbpic_ip1_b1.name = 'IP1'
+    bbpic_ip1_b2.name = 'IP1'
+    bbpic_ip1_b1.partner_name = 'p_b2'
+    bbpic_ip1_b2.partner_name = 'p_b1'
+    particles_b1_pic.init_pipeline('p_b1')
+    particles_b2_pic.init_pipeline('p_b2')
+    bbpic_ip1_b1.pipeline_manager = pipeline_manager
+    bbpic_ip1_b2.pipeline_manager = pipeline_manager
+    
+    ######################
+    # set up xtrack line #
+    ######################
+    
+    line_b1 = xt.Line(elements=[bbpic_ip1_b1])
+    line_b2 = xt.Line(elements=[bbpic_ip1_b2])
+    
+    line_b1.build_tracker(_context=test_context)
+    line_b2.build_tracker(_context=test_context)
+    
+    multitracker = xt.PipelineMultiTracker(
+        branches=[xt.PipelineBranch(line=line_b1, particles=particles_b1_pic),
+                  xt.PipelineBranch(line=line_b2, particles=particles_b2_pic)],
+        enable_debug_log=True, verbose=True)
+    
+    ################
+    # configure BS #
+    ################
+    
+    assert line_b1._needs_rng == False
+    line_b1.configure_radiation(model_beamstrahlung='quantum')
+    assert line_b1._needs_rng == True
+    
+    assert line_b2._needs_rng == False
+    line_b2.configure_radiation(model_beamstrahlung='quantum')
+    assert line_b2._needs_rng == True
+    
+    record_b1_pic = line_b1.start_internal_logging_for_elements_of_type(
+        xf.BeamBeamPIC3D, capacity={"beamstrahlungtable": int(3e5)})
+    record_b2_pic = line_b2.start_internal_logging_for_elements_of_type(
+        xf.BeamBeamPIC3D, capacity={"beamstrahlungtable": int(3e5)})
+    
+    #####################
+    # track 1 collision #
+    #####################
+    
+    multitracker.track(num_turns=1)
+    
+    line_b1.stop_internal_logging_for_elements_of_type(xf.BeamBeamPIC3D)
+    line_b2.stop_internal_logging_for_elements_of_type(xf.BeamBeamPIC3D)
+    
+    #####################################
+    # test #1: compare against formulas #
+    #####################################
+    
+    # analytical beamstrahlung parameters
+    r0 = cst.e**2/(4*np.pi*cst.epsilon_0*cst.m_e*cst.c**2) # - if pp
+    upsilon_max = (
+        2 * r0**2 * energy/(mass0*1e-9) * bunch_intensity
+        / (1/137*sigma_z_tot*(sigma_x + 1.85*sigma_y)))
+    upsilon_avg = (5/6 * r0**2 * energy/(mass0*1e-9) * bunch_intensity
+                    / (1/137*sigma_z_tot*(sigma_x + sigma_y)))
+    
+    # get rid of padded zeros in table
+    photon_critical_energy_b1 = record_b1_pic.beamstrahlungtable.photon_critical_energy
+    photon_critical_energy_b2 = record_b2_pic.beamstrahlungtable.photon_critical_energy
+    primary_energy_b1         = record_b1_pic.beamstrahlungtable.primary_energy
+    primary_energy_b2         = record_b2_pic.beamstrahlungtable.primary_energy
+    
+    photon_critical_energy_b1 = photon_critical_energy_b1[photon_critical_energy_b1>0]
+    photon_critical_energy_b2 = photon_critical_energy_b2[photon_critical_energy_b2>0]
+    primary_energy_b1         = primary_energy_b1[primary_energy_b1>0]
+    primary_energy_b2         = primary_energy_b2[primary_energy_b2>0]
+    
+    upsilon_avg_sim_b1 = np.mean(0.67 * photon_critical_energy_b1 / primary_energy_b1)
+    upsilon_avg_sim_b2 = np.mean(0.67 * photon_critical_energy_b2 / primary_energy_b2)
+    upsilon_max_sim_b1 = np.max( 0.67 * photon_critical_energy_b1 / primary_energy_b1)
+    upsilon_max_sim_b2 = np.max( 0.67 * photon_critical_energy_b2 / primary_energy_b2)
+    
+    print("Y max. [1]:", upsilon_max)
+    print("Y avg. [1]:", upsilon_avg)
+    print("Y max. beam 1 [1]:", upsilon_max_sim_b1)
+    print("Y avg. beam 1 [1]:", upsilon_avg_sim_b1)
+    print("Y max. beam 2 [1]:", upsilon_max_sim_b2)
+    print("Y avg. beam 2 [1]:", upsilon_avg_sim_b2)
+    print("Y max. ratio beam 1 [1]:", upsilon_max_sim_b1 / upsilon_max)
+    print("Y avg. ratio beam 1 [1]:", upsilon_avg_sim_b1 / upsilon_avg)
+    print("Y max. ratio beam 2 [1]:", upsilon_max_sim_b2 / upsilon_max)
+    print("Y avg. ratio beam 2 [1]:", upsilon_avg_sim_b2 / upsilon_avg)
+    
+    rtol = 1e-1
+    assert np.allclose(upsilon_max_sim_b1, upsilon_max, rtol=rtol), f"Upsilon max beam 1 does not agree with {rtol} tolerance!"
+    assert np.allclose(upsilon_avg_sim_b1, upsilon_avg, rtol=rtol), f"Upsilon avg beam 1 does not agree with {rtol} tolerance!"
+    assert np.allclose(upsilon_max_sim_b2, upsilon_max, rtol=rtol), f"Upsilon max beam 2 does not agree with {rtol} tolerance!"
+    assert np.allclose(upsilon_avg_sim_b2, upsilon_avg, rtol=rtol), f"Upsilon avg beam 2 does not agree with {rtol} tolerance!"
+    
+    ###############################################################
+    # test #2: compare BS photon E spectrum against soft-gaussian #
+    ###############################################################
+    
+    n_bins = 20
+    bins = np.logspace(np.log10(1e-9), np.log10(1e10), 20)
+    
+    hist_big = np.array([991, 2176, 4559, 9885, 20741, 40261, 56973, 23659, 165])  # this comes from an Xsuite SS simulation with soft-Gaussian bb using 1e6 macroparticles, 100 slices, 1 collision, then the beamstrahlung photon energies from beam 1 are histogrammed using the same binning as above
+    photons_pic_b1 = set(record_b1_pic.beamstrahlungtable.photon_energy)
+    photons_pic_b2 = set(record_b2_pic.beamstrahlungtable.photon_energy)
+    
+    # compare the upper part of the energy spectrum bc it has better statistics than low end tail
+    hist_pic_b1 = np.histogram(np.array([*photons_pic_b1]), bins=bins)[0][int(n_bins/2):]
+    hist_pic_b2 = np.histogram(np.array([*photons_pic_b2]), bins=bins)[0][int(n_bins/2):]
+    
+    rtol = 20e-1  # should agree within 20%, actually within a few % except for the upper tail bin
+    assert np.allclose(hist_pic_b1,    hist_big, rtol=rtol), f"PIC beam 1 and soft-Gaussian beam 1 photon energies do not agree {rtol} tolerance"
+    assert np.allclose(hist_pic_b2,    hist_big, rtol=rtol), f"PIC beam 2 and soft-Gaussian beam 1 photon energies do not agree {rtol} tolerance"
+    assert np.allclose(hist_pic_b1, hist_pic_b2, rtol=rtol), f"PIC beam 1 and PIC beam 2 photon energies do not agree {rtol} tolerance"
+    

--- a/tests/test_beamstrahlung_pic.py
+++ b/tests/test_beamstrahlung_pic.py
@@ -24,6 +24,7 @@ def test_beambeam3d_beamstrahlung_pic(test_context):
     print(repr(test_context))
 
     # fcc ttbar 4 IP
+    # https://indico.cern.ch/event/1202105/contributions/5408583/attachments/2659051/4608141/FCCWeek_Optics_Oide_230606.pdf
     bunch_intensity     =  1.55e11  # [e]
     energy              =  182.5  # [GeV]
     p0c                 =  182.5e9  # [eV]
@@ -153,7 +154,7 @@ def test_beambeam3d_beamstrahlung_pic(test_context):
         xf.BeamBeamPIC3D, capacity={"beamstrahlungtable": int(3e5)})
     record_b2_pic = line_b2.start_internal_logging_for_elements_of_type(
         xf.BeamBeamPIC3D, capacity={"beamstrahlungtable": int(3e5)})
-    
+
     #####################
     # track 1 collision #
     #####################
@@ -162,7 +163,10 @@ def test_beambeam3d_beamstrahlung_pic(test_context):
     
     line_b1.stop_internal_logging_for_elements_of_type(xf.BeamBeamPIC3D)
     line_b2.stop_internal_logging_for_elements_of_type(xf.BeamBeamPIC3D)
-    
+
+    record_b1_pic.move(_context=xo.context_default)
+    record_b2_pic.move(_context=xo.context_default)
+
     #####################################
     # test #1: compare against formulas #
     #####################################
@@ -176,15 +180,10 @@ def test_beambeam3d_beamstrahlung_pic(test_context):
                     / (1/137*sigma_z_tot*(sigma_x + sigma_y)))
     
     # get rid of padded zeros in table
-    photon_critical_energy_b1 = record_b1_pic.beamstrahlungtable.photon_critical_energy
-    photon_critical_energy_b2 = record_b2_pic.beamstrahlungtable.photon_critical_energy
-    primary_energy_b1         = record_b1_pic.beamstrahlungtable.primary_energy
-    primary_energy_b2         = record_b2_pic.beamstrahlungtable.primary_energy
-    
-    photon_critical_energy_b1 = photon_critical_energy_b1[photon_critical_energy_b1>0]
-    photon_critical_energy_b2 = photon_critical_energy_b2[photon_critical_energy_b2>0]
-    primary_energy_b1         = primary_energy_b1[primary_energy_b1>0]
-    primary_energy_b2         = primary_energy_b2[primary_energy_b2>0]
+    photon_critical_energy_b1 = np.array(sorted(set(record_b1_pic.beamstrahlungtable.photon_critical_energy))[1:])
+    photon_critical_energy_b2 = np.array(sorted(set(record_b2_pic.beamstrahlungtable.photon_critical_energy))[1:])
+    primary_energy_b1         = np.array(sorted(set(        record_b1_pic.beamstrahlungtable.primary_energy))[1:])
+    primary_energy_b2         = np.array(sorted(set(        record_b2_pic.beamstrahlungtable.primary_energy))[1:])
     
     upsilon_avg_sim_b1 = np.mean(0.67 * photon_critical_energy_b1 / primary_energy_b1)
     upsilon_avg_sim_b2 = np.mean(0.67 * photon_critical_energy_b2 / primary_energy_b2)

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -172,6 +172,7 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
         # beamstrahlung
         'flag_beamstrahlung': xo.Int64,
+        'slices_other_beam_zeta_bin_width_beamstrahlung': xo.Float64[:],
         'slices_other_beam_zeta_bin_width_star_beamstrahlung': xo.Float64[:],
         'slices_other_beam_sqrtSigma_11_beamstrahlung': xo.Float64[:],
         'slices_other_beam_sqrtSigma_33_beamstrahlung': xo.Float64[:],
@@ -517,7 +518,8 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
             slices_other_beam_py_center_star=n_slices,
             slices_other_beam_zeta_center_star=n_slices,
             slices_other_beam_pzeta_center_star=n_slices,
-            slices_other_beam_zeta_bin_width_star_beamstrahlung=n_slices,  # beamstrahlung
+            slices_other_beam_zeta_bin_width_beamstrahlung=n_slices,  # beamstrahlung
+            slices_other_beam_zeta_bin_width_star_beamstrahlung=n_slices,
             slices_other_beam_sqrtSigma_11_beamstrahlung=n_slices,
             slices_other_beam_sqrtSigma_33_beamstrahlung=n_slices,
             slices_other_beam_sqrtSigma_55_beamstrahlung=n_slices,
@@ -544,24 +546,48 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
                             self.config_for_update.slicer.bin_widths_beamstrahlung
                                 / np.cos(self.phi))
 
-        if (slices_other_beam_zeta_bin_width_star_beamstrahlung is None and
-            slices_other_beam_zeta_bin_width_beamstrahlung is not None):
+#        if (slices_other_beam_zeta_bin_width_star_beamstrahlung is None and
+#            slices_other_beam_zeta_bin_width_beamstrahlung is not None):
+#            assert not np.isscalar(slices_other_beam_zeta_bin_width_beamstrahlung), (
+#                'slices_other_beam_zeta_bin_width_beamstrahlung must be an array')
+#            assert (len(slices_other_beam_zeta_bin_width_beamstrahlung)
+#                == len(self.slices_other_beam_num_particles))
+#            slices_other_beam_zeta_bin_width_star_beamstrahlung = (
+#                slices_other_beam_zeta_bin_width_beamstrahlung / np.cos(self.phi))
+#
+#        if slices_other_beam_zeta_bin_width_star_beamstrahlung is not None:
+#            assert not np.isscalar(slices_other_beam_zeta_bin_width_star_beamstrahlung), (
+#                'slices_other_beam_zeta_bin_width_star_beamstrahlung must be an array')
+#            assert (len(slices_other_beam_zeta_bin_width_star_beamstrahlung)
+#                == len(self.slices_other_beam_num_particles))
+#            self.slices_other_beam_zeta_bin_width_star_beamstrahlung = self._arr2ctx(
+#                np.array(slices_other_beam_zeta_bin_width_star_beamstrahlung))
+
+        if slices_other_beam_zeta_bin_width_beamstrahlung is not None:
             assert not np.isscalar(slices_other_beam_zeta_bin_width_beamstrahlung), (
                 'slices_other_beam_zeta_bin_width_beamstrahlung must be an array')
             assert (len(slices_other_beam_zeta_bin_width_beamstrahlung)
                 == len(self.slices_other_beam_num_particles))
             slices_other_beam_zeta_bin_width_star_beamstrahlung = (
                 slices_other_beam_zeta_bin_width_beamstrahlung / np.cos(self.phi))
-
-        if slices_other_beam_zeta_bin_width_star_beamstrahlung is not None:
+            self.slices_other_beam_zeta_bin_width_beamstrahlung = self._arr2ctx(
+                np.array(slices_other_beam_zeta_bin_width_beamstrahlung))
+            self.slices_other_beam_zeta_bin_width_star_beamstrahlung = self._arr2ctx(
+                np.array(slices_other_beam_zeta_bin_width_star_beamstrahlung))
+        elif slices_other_beam_zeta_bin_width_star_beamstrahlung is not None:
             assert not np.isscalar(slices_other_beam_zeta_bin_width_star_beamstrahlung), (
                 'slices_other_beam_zeta_bin_width_star_beamstrahlung must be an array')
             assert (len(slices_other_beam_zeta_bin_width_star_beamstrahlung)
                 == len(self.slices_other_beam_num_particles))
+            slices_other_beam_zeta_bin_width_beamstrahlung = (
+                slices_other_beam_zeta_bin_width_star_beamstrahlung * np.cos(self.phi))
+            self.slices_other_beam_zeta_bin_width_beamstrahlung = self._arr2ctx(
+                np.array(slices_other_beam_zeta_bin_width_beamstrahlung))
             self.slices_other_beam_zeta_bin_width_star_beamstrahlung = self._arr2ctx(
                 np.array(slices_other_beam_zeta_bin_width_star_beamstrahlung))
         else:
             self.slices_other_beam_zeta_bin_width_star_beamstrahlung[:] = 0
+            self.slices_other_beam_zeta_bin_width_beamstrahlung[:] = 0
 
         if slices_other_beam_sqrtSigma_11_beamstrahlung is not None:
             assert not np.isscalar(slices_other_beam_sqrtSigma_11_beamstrahlung), (
@@ -928,7 +954,53 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
     @phi.setter
     def phi(self, value):
-        raise NotImplementedError("Setting phi is not implemented yet")
+        #raise NotImplementedError("Setting phi is not implemented yet")
+        _init_alpha_phi(self, phi=value)
+
+        # Trigger properties to set corresponding starred quantities
+        self._init_Sigmas(
+            self.slices_other_beam_Sigma_11,
+            self.slices_other_beam_Sigma_12,
+            self.slices_other_beam_Sigma_13,
+            self.slices_other_beam_Sigma_14,
+            self.slices_other_beam_Sigma_22,
+            self.slices_other_beam_Sigma_23,
+            self.slices_other_beam_Sigma_24,
+            self.slices_other_beam_Sigma_33,
+            self.slices_other_beam_Sigma_34,
+            self.slices_other_beam_Sigma_44,
+
+            self.slices_other_beam_Sigma_11_star,
+            self.slices_other_beam_Sigma_12_star,
+            self.slices_other_beam_Sigma_13_star,
+            self.slices_other_beam_Sigma_14_star,
+            self.slices_other_beam_Sigma_22_star,
+            self.slices_other_beam_Sigma_23_star,
+            self.slices_other_beam_Sigma_24_star,
+            self.slices_other_beam_Sigma_33_star,
+            self.slices_other_beam_Sigma_34_star,
+            self.slices_other_beam_Sigma_44_star,
+        )
+
+        # Initialize slice positions in the boosted frame. Depends on phi, alpha
+        self._init_starred_positions(
+            self.slices_other_beam_num_particles,
+            self.slices_other_beam_x_center, self.slices_other_beam_px_center,
+            self.slices_other_beam_y_center, self.slices_other_beam_py_center,
+            self.slices_other_beam_zeta_center, self.slices_other_beam_pzeta_center,
+            self.slices_other_beam_x_center_star, self.slices_other_beam_px_center_star,
+            self.slices_other_beam_y_center_star, self.slices_other_beam_py_center_star,
+            self.slices_other_beam_zeta_center_star, self.slices_other_beam_pzeta_center_star)
+
+        # Initialize beamstrahlung related quantities. Depends on phi, alpha
+        self._init_beamstrahlung(
+            self.flag_beamstrahlung,
+            self.slices_other_beam_zeta_bin_width_beamstrahlung,
+            self.slices_other_beam_zeta_bin_width_star_beamstrahlung,
+            self.slices_other_beam_sqrtSigma_11_beamstrahlung,
+            self.slices_other_beam_sqrtSigma_33_beamstrahlung,
+            self.slices_other_beam_sqrtSigma_55_beamstrahlung,
+        )
 
     @property
     def alpha(self):
@@ -936,7 +1008,53 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
 
     @alpha.setter
     def alpha(self, value):
-        raise NotImplementedError("Setting alpha is not implemented yet")
+        #raise NotImplementedError("Setting alpha is not implemented yet")
+        _init_alpha_phi(self, alpha=value)
+
+        # Trigger properties to set corresponding starred quantities
+        self._init_Sigmas(
+            self.slices_other_beam_Sigma_11,
+            self.slices_other_beam_Sigma_12,
+            self.slices_other_beam_Sigma_13,
+            self.slices_other_beam_Sigma_14,
+            self.slices_other_beam_Sigma_22,
+            self.slices_other_beam_Sigma_23,
+            self.slices_other_beam_Sigma_24,
+            self.slices_other_beam_Sigma_33,
+            self.slices_other_beam_Sigma_34,
+            self.slices_other_beam_Sigma_44,
+
+            self.slices_other_beam_Sigma_11_star,
+            self.slices_other_beam_Sigma_12_star,
+            self.slices_other_beam_Sigma_13_star,
+            self.slices_other_beam_Sigma_14_star,
+            self.slices_other_beam_Sigma_22_star,
+            self.slices_other_beam_Sigma_23_star,
+            self.slices_other_beam_Sigma_24_star,
+            self.slices_other_beam_Sigma_33_star,
+            self.slices_other_beam_Sigma_34_star,
+            self.slices_other_beam_Sigma_44_star,
+        )
+
+        # Initialize slice positions in the boosted frame
+        self._init_starred_positions(
+            self.slices_other_beam_num_particles,
+            self.slices_other_beam_x_center, self.slices_other_beam_px_center,
+            self.slices_other_beam_y_center, self.slices_other_beam_py_center,
+            self.slices_other_beam_zeta_center, self.slices_other_beam_pzeta_center,
+            self.slices_other_beam_x_center_star, self.slices_other_beam_px_center_star,
+            self.slices_other_beam_y_center_star, self.slices_other_beam_py_center_star,
+            self.slices_other_beam_zeta_center_star, self.slices_other_beam_pzeta_center_star)
+
+        # Initialize beamstrahlung related quantities
+        self._init_beamstrahlung(
+            self.flag_beamstrahlung,
+            self.slices_other_beam_zeta_bin_width_beamstrahlung,
+            self.slices_other_beam_zeta_bin_width_star_beamstrahlung,
+            self.slices_other_beam_sqrtSigma_11_beamstrahlung,
+            self.slices_other_beam_sqrtSigma_33_beamstrahlung,
+            self.slices_other_beam_sqrtSigma_55_beamstrahlung,
+        )
 
     def _inv_boost_slice_centers(self):
 

--- a/xfields/beam_elements/beambeam3d.py
+++ b/xfields/beam_elements/beambeam3d.py
@@ -882,8 +882,8 @@ class BeamBeamBiGaussian3D(xt.BeamElement):
                                                 at_turn,
                                                 internal_tag=self.config_for_update._i_step):
             # Compute moments
-            self.config_for_update.slicer.assign_slices(particles)  # in this the bin edges are fixed with TempSlicer
-            self.moments = self.config_for_update.slicer.compute_moments(particles,update_assigned_slices=False)
+            #self.config_for_update.slicer.assign_slices(particles)  # in this the bin edges are fixed with TempSlicer
+            self.moments = self.config_for_update.slicer.compute_moments(particles)  # assign to slices happens inside here
 
             pipeline_manager.send_message(self.moments,
                                                 self.config_for_update.element_name,

--- a/xfields/beam_elements/beambeam3dpic.py
+++ b/xfields/beam_elements/beambeam3dpic.py
@@ -257,14 +257,14 @@ class BeamBeamPIC3D(xt.BeamElement):
         # Compute particles coordinates in the reference system of the other beam
         z_step_self = self._z_steps_self[self._i_step]
         mask_alive = pp.state > 0
-        z_step_other = self._z_steps_other[self._i_step]
+        z_step_other = self._z_steps_other[self._i_step]  # same as z_step_self
         # For now assuming symmetric ultra-relativistic beams
         z_other = (-pp.zeta[mask_alive] + z_step_other + z_step_self)
         x_other = -pp.x[mask_alive]
         y_other = pp.y[mask_alive]
 
         # Get fields in the reference system of the other beam
-        dphi_dx, dphi_dy, dphi_dz = self.fieldmap_other.get_values_at_points(
+        dphi_dx, dphi_dy, dphi_dz = self.fieldmap_other.get_values_at_points(  # all 0s at first step since other beam hasnt sent its rho yet
             x=x_other, y=y_other, z=z_other,
             return_rho=False,
             return_phi=False,
@@ -333,7 +333,7 @@ class BeamBeamPIC3D(xt.BeamElement):
     def flag_beamstrahlung(self):
         return self._flag_beamstrahlung
 
-    #@flag_beamstrahlung.setter
+    @flag_beamstrahlung.setter
     def flag_beamstrahlung(self, flag_beamstrahlung):
         self._flag_beamstrahlung = flag_beamstrahlung
 

--- a/xfields/beam_elements/beambeam3dpic.py
+++ b/xfields/beam_elements/beambeam3dpic.py
@@ -14,6 +14,41 @@ from ..general import _pkg_root
 from .beambeam3d import _init_alpha_phi
 from xfields import TriLinearInterpolatedFieldMap
 
+class BeamstrahlungTable(xo.HybridClass):
+    """
+    Buffer size should be larger than the number of expected BS photons emitted. Test on single collision for estimate.
+    If more photons are emitted than the buffer size, the surplus data will be dropped.
+    Photons from multiple turns and beambeam elements are stored in the same buffer.
+    Photons are 'macro' i.e. represent the dynamics of bunch_intensity/n_macroparticles real BS photons.
+    This implies that the number of emitted BS photons scales linearly with n_macroparticles.
+
+    Fields:
+     _index: custom C struct for metadata
+     at_element: [1] element index in the xtrack.Line object, starts with 0
+     at_turn: [1] turn index, starts with 0
+     particle_id: [1] array index in the xpart.Particles object of the primary macroparticle emitting the photon
+     primary_energy: [eV] total energy of primary macroparticle before emission of this photon
+     photon_id: [1] counter for photons emitted from the same primary in the same collision with a single slice
+     photon_energy: [eV] total energy of a beamstrahlung photon
+     photon_critical_energy (with quantum BS only): [eV] critical energy of a beamstrahlung photon
+     rho_inv (with quantum BS only): [m^-1] (Fr/dz) inverse bending radius of the primary macroparticle
+    """
+    _xofields = {
+      '_index': xt.RecordIndex,
+      'at_element': xo.Int64[:],
+      'at_turn': xo.Int64[:],
+      'particle_id': xo.Int64[:],
+      'primary_energy': xo.Float64[:],
+      'photon_id': xo.Float64[:],
+      'photon_energy': xo.Float64[:],
+      'photon_critical_energy': xo.Float64[:],
+      'rho_inv': xo.Float64[:],
+        }
+
+class BeamBeamPIC3DRecord(xo.HybridClass):
+    _xofields = {
+        'beamstrahlungtable': BeamstrahlungTable,
+       }
 
 class BeamBeamPIC3D(xt.BeamElement):
 
@@ -49,16 +84,27 @@ class BeamBeamPIC3D(xt.BeamElement):
         'fieldmap_self': TriLinearInterpolatedFieldMap,
         'fieldmap_other': TriLinearInterpolatedFieldMap,
 
+        # beamstrahlung
+        'flag_beamstrahlung': xo.Int64,
     }
     iscollective = True
+
+    _internal_record_class = BeamBeamPIC3DRecord
+
+    _rename = {'flag_beamstrahlung': '_flag_beamstrahlung'}
+
+    _depends_on = [xt.RandomUniform]
 
     _extra_c_sources= [
         _pkg_root.joinpath('headers/constants.h'),
         _pkg_root.joinpath('headers/sincos.h'),
         _pkg_root.joinpath('headers/power_n.h'),
+        _pkg_root.joinpath('headers','particle_states.h'),
         _pkg_root.joinpath('beam_elements/beambeam_src/beambeam3d_ref_frame_changes.h'),
 
         # beamstrahlung
+        _pkg_root.joinpath(
+            'headers/beamstrahlung_spectrum_pic.h'), # merge two headers using a template
         _pkg_root.joinpath(
             'beam_elements/beambeam_src/beambeampic_methods.h'),
 
@@ -89,6 +135,7 @@ class BeamBeamPIC3D(xt.BeamElement):
                  nx=None, ny=None, nz=None,
                  dx=None, dy=None, dz=None,
                  x_grid=None, y_grid=None, z_grid=None,
+                 flag_beamstrahlung=0,
                  _context=None, _buffer=None,
                  **kwargs):
 
@@ -131,6 +178,10 @@ class BeamBeamPIC3D(xt.BeamElement):
                 _cos_alpha=kwargs.get('cos_alpha', None))
 
         self._working_on_bunch = None
+
+        # Initialize beamstrahlung related quantities
+        self.flag_beamstrahlung = flag_beamstrahlung # Trigger property setter
+
 
     def track(self, particles):
 
@@ -277,4 +328,13 @@ class BeamBeamPIC3D(xt.BeamElement):
     @alpha.setter
     def alpha(self, value):
         raise NotImplementedError("Setting alpha is not implemented yet")
+
+    @property
+    def flag_beamstrahlung(self):
+        return self._flag_beamstrahlung
+
+    #@flag_beamstrahlung.setter
+    def flag_beamstrahlung(self, flag_beamstrahlung):
+        self._flag_beamstrahlung = flag_beamstrahlung
+
 

--- a/xfields/beam_elements/beambeam_src/beambeam3d.h
+++ b/xfields/beam_elements/beambeam_src/beambeam3d.h
@@ -304,10 +304,6 @@ void synchrobeam_kick(
                 Fx_star*(*px_star+0.5*Fx_star - px_slice_star)+
                 Fy_star*(*py_star+0.5*Fy_star - py_slice_star));
 
-    FILE* f1 = fopen("/Users/pkicsiny/phd/cern/xsuite/outputs/n141_test_beambeam_pic_single_coll/xsuite_forces.txt","a");
-    fprintf(f1, "%g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g \n", q0, *x_star, *y_star, *zeta_star, *px_star, *py_star, *pzeta_star, x_bar_star, y_bar_star, Fx_star, Fy_star, dpzeta_star, S, Ksl, Fx_hat_star, Fy_hat_star, num_part_slice);
-    fclose(f1);
-
     // Apply the kicks (Hirata's synchro-beam)
     *pzeta_star = *pzeta_star + dpzeta_star;
     *x_star = *x_star - S*Fx_star;

--- a/xfields/beam_elements/beambeam_src/beambeam3d.h
+++ b/xfields/beam_elements/beambeam_src/beambeam3d.h
@@ -149,8 +149,7 @@ void do_beamstrahlung(BeamBeamBiGaussian3DData el, LocalParticle *part,
         }
 
         *pzeta_star = LocalParticle_get_pzeta(part);  // BS rescales energy vars, so load again before kick
-    }
-
+}
 
 
 /*gpufun*/
@@ -304,6 +303,10 @@ void synchrobeam_kick(
     double const dpzeta_star = Fz_star + 0.5 * (
                 Fx_star*(*px_star+0.5*Fx_star - px_slice_star)+
                 Fy_star*(*py_star+0.5*Fy_star - py_slice_star));
+
+    FILE* f1 = fopen("/Users/pkicsiny/phd/cern/xsuite/outputs/n141_test_beambeam_pic_single_coll/xsuite_forces.txt","a");
+    fprintf(f1, "%g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g %g \n", q0, *x_star, *y_star, *zeta_star, *px_star, *py_star, *pzeta_star, x_bar_star, y_bar_star, Fx_star, Fy_star, dpzeta_star, S, Ksl, Fx_hat_star, Fy_hat_star, num_part_slice);
+    fclose(f1);
 
     // Apply the kicks (Hirata's synchro-beam)
     *pzeta_star = *pzeta_star + dpzeta_star;

--- a/xfields/beam_elements/beambeam_src/beambeampic_methods.h
+++ b/xfields/beam_elements/beambeam_src/beambeampic_methods.h
@@ -6,6 +6,35 @@
 #ifndef XFIELDS_BEAMBEAMPIC_METHODS_H
 #define XFIELDS_BEAMBEAMPIC_METHODS_H
 
+/*gpufun*/
+void do_beamstrahlung_pic(BeamBeamPIC3DData el, LocalParticle *part,
+                      double Fx_star, double Fy_star,
+                      double* pzeta_star, double const dz,
+                      const int64_t flag_beamstrahlung){
+
+        // init record table
+        BeamBeamPIC3DRecordData beamstrahlung_record = NULL;
+        BeamstrahlungTableData beamstrahlung_table          = NULL;
+        RecordIndex beamstrahlung_table_index               = NULL;
+        beamstrahlung_record = BeamBeamPIC3DData_getp_internal_record(el, part);
+        if (beamstrahlung_record){
+            beamstrahlung_table       = BeamBeamPIC3DRecordData_getp_beamstrahlungtable(beamstrahlung_record);
+            beamstrahlung_table_index =                 BeamstrahlungTableData_getp__index(beamstrahlung_table);
+        }
+
+        LocalParticle_update_pzeta(part, *pzeta_star);  // update energy vars with boost and/or last kick
+
+	if(flag_beamstrahlung==1){
+            // no average beamstrahlung implemented
+	} else if (flag_beamstrahlung==2){
+            double const Fr = hypot(Fx_star, Fy_star) * LocalParticle_get_rpp(part); // radial kick [1]
+            double const dz_half = .5*dz;  // half slice width [m] from grid cell size 0.5*dz
+            beamstrahlung(part, beamstrahlung_record, beamstrahlung_table_index, beamstrahlung_table, Fr, dz_half);
+        }
+
+        *pzeta_star = LocalParticle_get_pzeta(part);  // BS rescales energy vars, so load again before kick
+}
+
 
 /*gpufun*/
 void BeamBeamPIC3D_change_ref_frame_local_particle(
@@ -161,7 +190,7 @@ void BeamBeamPIC3D_kick_and_propagate_transverse_coords_back(
         double y = LocalParticle_get_y(part);
         double px = LocalParticle_get_px(part);
         double py = LocalParticle_get_py(part);
-        double delta = LocalParticle_get_delta(part);
+        double pzeta = LocalParticle_get_pzeta(part);
         double zeta = LocalParticle_get_zeta(part);
         double beta0 = LocalParticle_get_beta0(part);
         double gamma0 = LocalParticle_get_gamma0(part);
@@ -184,12 +213,24 @@ void BeamBeamPIC3D_kick_and_propagate_transverse_coords_back(
         // Effect of the particle angle as in Hirata
         double dpz = 0.5 * (dpx * (px + 0.5 * dpx) + dpy * (py + 0.5 * dpy));
 
+        FILE* f1 = fopen("/Users/pkicsiny/phd/cern/xsuite/outputs/n141_test_beambeam_pic_single_coll/xsuite_pic_forces.txt","a");
+        fprintf(f1, "%g %g %g %g %g %g %g %g %g %g %g \n", q0, x, y, zeta, px, py, pzeta, dpx, dpy, dpz, factor);
+        fclose(f1);
+
+        // emit beamstrahlung photons from single macropart
+        #ifndef XFIELDS_BB3D_NO_BEAMSTR
+        const int64_t flag_beamstrahlung = BeamBeamPIC3DData_get_flag_beamstrahlung(el);
+        if(flag_beamstrahlung!=0){
+            do_beamstrahlung_pic(el, part, dpx, dpy, &pzeta, dz, flag_beamstrahlung); // no avg only quantum
+        }
+        #endif 
+
         // Apply kick
         px += dpx;
         py += dpy;
         LocalParticle_set_px(part, px);
         LocalParticle_set_py(part, py);
-        LocalParticle_update_delta(part, delta + dpz);
+        LocalParticle_update_pzeta(part, pzeta + dpz);
 
         // Propagate transverse coordinates back to IP
         double ptau = LocalParticle_get_ptau(part);

--- a/xfields/beam_elements/beambeam_src/beambeampic_methods.h
+++ b/xfields/beam_elements/beambeam_src/beambeampic_methods.h
@@ -14,12 +14,12 @@ void do_beamstrahlung_pic(BeamBeamPIC3DData el, LocalParticle *part,
 
         // init record table
         BeamBeamPIC3DRecordData beamstrahlung_record = NULL;
-        BeamstrahlungTableData beamstrahlung_table          = NULL;
-        RecordIndex beamstrahlung_table_index               = NULL;
+        BeamstrahlungTableData beamstrahlung_table   = NULL;
+        RecordIndex beamstrahlung_table_index        = NULL;
         beamstrahlung_record = BeamBeamPIC3DData_getp_internal_record(el, part);
         if (beamstrahlung_record){
             beamstrahlung_table       = BeamBeamPIC3DRecordData_getp_beamstrahlungtable(beamstrahlung_record);
-            beamstrahlung_table_index =                 BeamstrahlungTableData_getp__index(beamstrahlung_table);
+            beamstrahlung_table_index =               BeamstrahlungTableData_getp__index(beamstrahlung_table);
         }
 
         LocalParticle_update_pzeta(part, *pzeta_star);  // update energy vars with boost and/or last kick
@@ -28,8 +28,7 @@ void do_beamstrahlung_pic(BeamBeamPIC3DData el, LocalParticle *part,
             // no average beamstrahlung implemented
 	} else if (flag_beamstrahlung==2){
             double const Fr = hypot(Fx_star, Fy_star) * LocalParticle_get_rpp(part); // radial kick [1]
-            double const dz_half = .5*dz;  // half slice width [m] from grid cell size 0.5*dz
-            beamstrahlung(part, beamstrahlung_record, beamstrahlung_table_index, beamstrahlung_table, Fr, dz_half);
+            beamstrahlung(part, beamstrahlung_record, beamstrahlung_table_index, beamstrahlung_table, Fr, dz);
         }
 
         *pzeta_star = LocalParticle_get_pzeta(part);  // BS rescales energy vars, so load again before kick
@@ -212,10 +211,6 @@ void BeamBeamPIC3D_kick_and_propagate_transverse_coords_back(
 
         // Effect of the particle angle as in Hirata
         double dpz = 0.5 * (dpx * (px + 0.5 * dpx) + dpy * (py + 0.5 * dpy));
-
-        FILE* f1 = fopen("/Users/pkicsiny/phd/cern/xsuite/outputs/n141_test_beambeam_pic_single_coll/xsuite_pic_forces.txt","a");
-        fprintf(f1, "%g %g %g %g %g %g %g %g %g %g %g \n", q0, x, y, zeta, px, py, pzeta, dpx, dpy, dpz, factor);
-        fclose(f1);
 
         // emit beamstrahlung photons from single macropart
         #ifndef XFIELDS_BB3D_NO_BEAMSTR

--- a/xfields/beam_elements/temp_slicer.py
+++ b/xfields/beam_elements/temp_slicer.py
@@ -279,10 +279,6 @@ class TempSlicer(xo.HybridClass):
 
         context = particles._context
 
-        # filter test particles which have weight=0. These are not included in the computation of moments.
-        mask = particles.weight > 0
-        particles = particles.filter(mask)
-
         # group particles into longitudinal slices
         if update_assigned_slices:
             self.assign_slices(particles)

--- a/xfields/beam_elements/temp_slicer.py
+++ b/xfields/beam_elements/temp_slicer.py
@@ -272,10 +272,6 @@ class TempSlicer(xo.HybridClass):
         particles.slice = self.get_slice_indices(particles)
 
     def compute_moments(self, particles, update_assigned_slices=True, threshold_num_macroparticles=20):
-        """
-        Takes into account the only particles with weight>0.
-        Assumes identical weight for each particles.
-        """
 
         context = particles._context
 

--- a/xfields/headers/bhabha_spectrum.h
+++ b/xfields/headers/bhabha_spectrum.h
@@ -196,12 +196,10 @@ void equal_newton(
     */
     double eps=1e-6;
     double ytry,xtry;
-    int i=0;
     xtry=*x;
     ytry=compt_int(xtry, x_compt);
     while (fabs(ytry-y)>(fabs(ytry)+fabs(y))*eps
            && (xmax-xmin)>eps) {
-        i++;
         xtry-=(ytry-y)/compt_diff(xtry, x_compt);
         if ((xtry>=xmax)||(xtry<=xmin)) {
             xtry=0.5*(xmax+xmin);


### PR DESCRIPTION
__remove test__ and __remove test docstring__
Removed 4 lines which were used for benchmarks in `temp_slicer.py`

__add phi and alpha setter with deferred expressions__

Implemented phi (crossing angle) and alpha (crossing plane) such that setter updates deferred expressions (other beam slice moments) in `beambeam3d.py`.

https://github.com/xsuite/xsuite/issues/611

Added a unit test `test_alpha_phi.py`.

__add unittest with beamstrahlung pic__

Added unit test for PIC solver with beamstrahlung: `test_beamstrahlung_pic.py`

__remove unused variable__

Removed unused variable in `bhabha_spectrum.h` that created warning upon compiling.

__fix beamstrahlung in quasi pic__ and __add beamstrahlung in beambeam3dpic__

Add beamstrahlung for PIC solver