### PR TITLE
Feature / fake multibunch tracking

### DIFF
--- a/xfields/__init__.py
+++ b/xfields/__init__.py
@@ -25,6 +25,7 @@ from .beam_elements.beambeam3dpic import BeamBeamPIC3D
 from .beam_elements.temp_slicer import TempSlicer
 from .beam_elements.electroncloud import ElectronCloud
 from .beam_elements.electronlens_interpolated import ElectronLensInterpolated
+from .beam_elements.waketracker import WakeTracker
 
 from .general import _pkg_root
 from .config_tools import replace_spacecharge_with_quasi_frozen

--- a/xfields/beam_elements/element_with_slicer.py
+++ b/xfields/beam_elements/element_with_slicer.py
@@ -77,6 +77,7 @@ class ElementWithSlicer(xt.BeamElement):
                 num_slices=num_slices,  # Per bunch, this is N_1 in the paper
                 bunch_spacing_zeta=bunch_spacing_zeta,  # This is P in the paper
                 filling_scheme=filling_scheme,
+                bunch_selection = bunch_selection,
                 num_turns=num_turns,
                 circumference=circumference)
 
@@ -104,6 +105,7 @@ class ElementWithSlicer(xt.BeamElement):
             num_slices=None,  # Per bunch, this is N_1 in the paper
             bunch_spacing_zeta=None,  # This is P in the paper
             filling_scheme=None,
+            bunch_selection = None,
             num_turns=1,
             circumference=None):
 
@@ -112,12 +114,18 @@ class ElementWithSlicer(xt.BeamElement):
             num_periods = i_last_bunch + 1
         else:
             num_periods = 1
+        if bunch_selection is not None:
+            num_targets = 1+bunch_selection[-1]-bunch_selection[0]
+        else:
+            num_targets = None
+            
         self.moments_data = CompressedProfile(
                 moments=self.source_moments + ['result'],
                 zeta_range=zeta_range,
                 num_slices=num_slices,
                 bunch_spacing_zeta=bunch_spacing_zeta,
                 num_periods=num_periods,
+                num_targets=num_targets,
                 num_turns=num_turns,
                 circumference=circumference,
                 _context=self.context)

--- a/xfields/beam_elements/element_with_slicer.py
+++ b/xfields/beam_elements/element_with_slicer.py
@@ -71,7 +71,7 @@ class ElementWithSlicer(xt.BeamElement):
                          bunch_spacing_zeta=bunch_spacing_zeta,
                          slicer_moments=slicer_moments)
 
-        if with_compressed_profile:
+        if with_compressed_profile: #TODO with a bunch selection, number of sources and targets should differ
             self._initialize_moments(
                 zeta_range=zeta_range,  # These are [a, b] in the paper
                 num_slices=num_slices,  # Per bunch, this is N_1 in the paper

--- a/xfields/beam_elements/element_with_slicer.py
+++ b/xfields/beam_elements/element_with_slicer.py
@@ -71,13 +71,12 @@ class ElementWithSlicer(xt.BeamElement):
                          bunch_spacing_zeta=bunch_spacing_zeta,
                          slicer_moments=slicer_moments)
 
-        if with_compressed_profile: #TODO with a bunch selection, number of sources and targets should differ
+        if with_compressed_profile:
             self._initialize_moments(
                 zeta_range=zeta_range,  # These are [a, b] in the paper
                 num_slices=num_slices,  # Per bunch, this is N_1 in the paper
                 bunch_spacing_zeta=bunch_spacing_zeta,  # This is P in the paper
                 filling_scheme=filling_scheme,
-                bunch_selection = bunch_selection,
                 num_turns=num_turns,
                 circumference=circumference)
 
@@ -105,7 +104,6 @@ class ElementWithSlicer(xt.BeamElement):
             num_slices=None,  # Per bunch, this is N_1 in the paper
             bunch_spacing_zeta=None,  # This is P in the paper
             filling_scheme=None,
-            bunch_selection = None,
             num_turns=1,
             circumference=None):
 
@@ -114,18 +112,12 @@ class ElementWithSlicer(xt.BeamElement):
             num_periods = i_last_bunch + 1
         else:
             num_periods = 1
-        if bunch_selection is not None:
-            num_targets = 1+bunch_selection[-1]-bunch_selection[0]
-        else:
-            num_targets = None
-            
         self.moments_data = CompressedProfile(
                 moments=self.source_moments + ['result'],
                 zeta_range=zeta_range,
                 num_slices=num_slices,
                 bunch_spacing_zeta=bunch_spacing_zeta,
                 num_periods=num_periods,
-                num_targets=num_targets,
                 num_turns=num_turns,
                 circumference=circumference,
                 _context=self.context)

--- a/xfields/beam_elements/element_with_slicer.py
+++ b/xfields/beam_elements/element_with_slicer.py
@@ -77,6 +77,7 @@ class ElementWithSlicer(xt.BeamElement):
                 num_slices=num_slices,  # Per bunch, this is N_1 in the paper
                 bunch_spacing_zeta=bunch_spacing_zeta,  # This is P in the paper
                 filling_scheme=filling_scheme,
+                bunch_selection=bunch_selection,
                 num_turns=num_turns,
                 circumference=circumference)
 
@@ -104,19 +105,28 @@ class ElementWithSlicer(xt.BeamElement):
             num_slices=None,  # Per bunch, this is N_1 in the paper
             bunch_spacing_zeta=None,  # This is P in the paper
             filling_scheme=None,
+            bunch_selection=None,
             num_turns=1,
             circumference=None):
+
 
         if filling_scheme is not None:
             i_last_bunch = np.where(filling_scheme)[0][-1]
             num_periods = i_last_bunch + 1
         else:
             num_periods = 1
+            
+        if bunch_selection is None:
+            num_targets = num_periods
+        else:
+            num_targets = 1+ np.max(bunch_selection)-np.min(bunch_selection)
+            
         self.moments_data = CompressedProfile(
                 moments=self.source_moments + ['result'],
                 zeta_range=zeta_range,
                 num_slices=num_slices,
                 bunch_spacing_zeta=bunch_spacing_zeta,
+                num_targets = num_targets,
                 num_periods=num_periods,
                 num_turns=num_turns,
                 circumference=circumference,

--- a/xfields/beam_elements/waketracker/convolution.py
+++ b/xfields/beam_elements/waketracker/convolution.py
@@ -81,13 +81,13 @@ class _ConvData:
             self._M_aux = moments_data._M_aux
             self._N_1 = moments_data._N_1
             self._N_S = moments_data._N_S
-            self._N_T = moments_data._N_S
+            self._N_T = moments_data._N_T
             self._BB = 1  # B in the paper
             # (for now we assume that B=0 is the first bunch in time and the
             # last one in zeta)
             self._AA = self._BB - self._N_S
-            self._CC = self._AA
-            self._DD = self._BB
+            self._DD = self.waketracker.slicer.bunch_selection[0]
+            self._CC = self._DD - self._N_T
 
             # Build wake matrix
             self.z_wake = _build_z_wake(moments_data._z_a, moments_data._z_b,
@@ -151,6 +151,7 @@ class _ConvData:
         # Compute convolution
         self._compute_convolution(moment_names=self.component.source_moments,
                                   moments_data=moments_data)
+
         # Apply kicks
         interpolated_result = particles.zeta * 0
         assert moments_data.moments_names[-1] == 'result'
@@ -164,6 +165,7 @@ class _ConvData:
             i_slot_particles=i_slot_particles,
             i_slice_particles=i_slice_particles,
             out=interpolated_result)
+
         # interpolated result will be zero for lost particles (so nothing to
         # do for them)
         scaling_constant = particles.q0**2 * qe**2 / (

--- a/xfields/beam_elements/waketracker/convolution.py
+++ b/xfields/beam_elements/waketracker/convolution.py
@@ -81,13 +81,13 @@ class _ConvData:
             self._M_aux = moments_data._M_aux
             self._N_1 = moments_data._N_1
             self._N_S = moments_data._N_S
-            self._N_T = moments_data._N_T
+            self._N_T = moments_data._N_S
             self._BB = 1  # B in the paper
             # (for now we assume that B=0 is the first bunch in time and the
             # last one in zeta)
             self._AA = self._BB - self._N_S
-            self._DD = self.waketracker.slicer.bunch_selection[0]
-            self._CC = self._DD - self._N_T
+            self._CC = self._AA
+            self._DD = self._BB
 
             # Build wake matrix
             self.z_wake = _build_z_wake(moments_data._z_a, moments_data._z_b,
@@ -151,7 +151,6 @@ class _ConvData:
         # Compute convolution
         self._compute_convolution(moment_names=self.component.source_moments,
                                   moments_data=moments_data)
-
         # Apply kicks
         interpolated_result = particles.zeta * 0
         assert moments_data.moments_names[-1] == 'result'
@@ -165,7 +164,6 @@ class _ConvData:
             i_slot_particles=i_slot_particles,
             i_slice_particles=i_slice_particles,
             out=interpolated_result)
-
         # interpolated result will be zero for lost particles (so nothing to
         # do for them)
         scaling_constant = particles.q0**2 * qe**2 / (

--- a/xfields/beam_elements/waketracker/convolution.py
+++ b/xfields/beam_elements/waketracker/convolution.py
@@ -248,6 +248,6 @@ def _build_z_wake(z_a, z_b, num_turns, n_aux, m_aux, circumference, dz,
             z_p = 0
 
         for ii, ll in enumerate(range(
-                cc - bb + 1, dd - aa)):
+                int(cc - bb + 1), int(dd - aa))):
             z_wake[tt, ii * n_aux:(ii + 1) * n_aux] = temp_z + ll * z_p
     return z_wake

--- a/xfields/beam_elements/waketracker/convolution.py
+++ b/xfields/beam_elements/waketracker/convolution.py
@@ -1,4 +1,5 @@
 import numpy as np
+from matplotlib import pyplot as plt
 from scipy.constants import e as qe
 
 import xobjects as xo
@@ -81,13 +82,13 @@ class _ConvData:
             self._M_aux = moments_data._M_aux
             self._N_1 = moments_data._N_1
             self._N_S = moments_data._N_S
-            self._N_T = moments_data._N_S
+            self._N_T = moments_data._N_T
             self._BB = 1  # B in the paper
             # (for now we assume that B=0 is the first bunch in time and the
             # last one in zeta)
             self._AA = self._BB - self._N_S
-            self._CC = self._AA
-            self._DD = self._BB
+            self._DD = -1*np.min(self.waketracker.slicer.bunch_selection)+1
+            self._CC = self._DD - self._N_T
 
             # Build wake matrix
             self.z_wake = _build_z_wake(moments_data._z_a, moments_data._z_b,
@@ -97,6 +98,7 @@ class _ConvData:
                                         moments_data.dz, self._AA,
                                         self._BB, self._CC, self._DD,
                                         moments_data._z_P)
+
             assert beta0 is not None
             # here below I had to add float() to beta0 because when using Cupy
             # context particles.beta0[0] turns out to be a 0d array. To be checked

--- a/xfields/beam_elements/waketracker/convolution.py
+++ b/xfields/beam_elements/waketracker/convolution.py
@@ -1,3 +1,4 @@
+import time
 import numpy as np
 from matplotlib import pyplot as plt
 from scipy.constants import e as qe
@@ -65,13 +66,17 @@ class _ConvData:
 
     def my_rfft(self, data, **kwargs):
         if type(self._context) in (xo.ContextCpu, xo.ContextCupy):
-            return self._context.nplike_lib.fft.rfft(data, **kwargs)
+            if hasattr(self._context,'omp_num_threads'):
+                kwargs['workers'] = self._context.omp_num_threads
+            return self._context.splike_lib.fft.rfft(data, **kwargs)
         else:
             raise NotImplementedError('Waketacker implemented only for CPU and Cupy')
 
     def my_irfft(self, data, **kwargs):
         if type(self._context) in (xo.ContextCpu, xo.ContextCupy):
-            return self._context.nplike_lib.fft.irfft(data, **kwargs)
+            if hasattr(self._context,'omp_num_threads'):
+                kwargs['workers'] = self._context.omp_num_threads
+            return self._context.splike_lib.fft.irfft(data, **kwargs)
         else:
             raise NotImplementedError('Waketacker implemented only for CPU and Cupy')
 

--- a/xfields/beam_elements/waketracker/convolution.py
+++ b/xfields/beam_elements/waketracker/convolution.py
@@ -66,7 +66,7 @@ class _ConvData:
 
     def my_rfft(self, data, **kwargs):
         if type(self._context) in (xo.ContextCpu, xo.ContextCupy):
-            if hasattr(self._context,'omp_num_threads'):
+            if hasattr(self._context,'omp_num_threads') and self._context.omp_num_threads > 1:
                 kwargs['workers'] = self._context.omp_num_threads
             return self._context.splike_lib.fft.rfft(data, **kwargs)
         else:
@@ -74,7 +74,7 @@ class _ConvData:
 
     def my_irfft(self, data, **kwargs):
         if type(self._context) in (xo.ContextCpu, xo.ContextCupy):
-            if hasattr(self._context,'omp_num_threads'):
+            if hasattr(self._context,'omp_num_threads') and self._context.omp_num_threads > 1:
                 kwargs['workers'] = self._context.omp_num_threads
             return self._context.splike_lib.fft.irfft(data, **kwargs)
         else:

--- a/xfields/beam_elements/waketracker/waketracker.py
+++ b/xfields/beam_elements/waketracker/waketracker.py
@@ -108,6 +108,7 @@ class WakeTracker(ElementWithSlicer):
             num_slices=num_slices,  # Per bunch, this is N_1 in the paper
             bunch_spacing_zeta=bunch_spacing_zeta,  # This is P in the paper
             filling_scheme=filling_scheme,
+            bunch_selection=bunch_selection,
             num_turns=num_turns,
             circumference=circumference)
 
@@ -143,16 +144,12 @@ class WakeTracker(ElementWithSlicer):
             cc._conv_data._initialize_conv_data(_flatten=self._flatten,
                                                 moments_data=self.moments_data,
                                                 beta0=beta0)
-
         # Use common slicer from parent class to measure all moments
         status = super().track(particles)
-
         if status and status.on_hold == True:
             return status
-
         if self.fake_coupled_bunch_phases:
             self._compute_fake_bunch_moments()
-
         for wf in self.components:
             wf._conv_data.track(particles,
                      i_slot_particles=self.i_slot_particles,
@@ -162,7 +159,7 @@ class WakeTracker(ElementWithSlicer):
     def _compute_fake_bunch_moments(self):
         conjugate_names = {'x':'px','y':'py'}
         for bunch_number,slot in enumerate(self.slicer.filled_slots):
-            if slot != self.bunch_selection[0]:  
+            if slot != self.bunch_selection[0]:
                 moments = {}
                 for moment_name in self.fake_coupled_bunch_phases.keys():
                     z_dummy,mom = self.moments_data.get_source_moment_profile(moment_name,0,0) 

--- a/xfields/beam_elements/waketracker/waketracker.py
+++ b/xfields/beam_elements/waketracker/waketracker.py
@@ -100,7 +100,7 @@ class WakeTracker(ElementWithSlicer):
             num_turns=num_turns,
             circumference=circumference,
             with_compressed_profile=True,
-            _context=self.context)
+            _context=self._context)
 
         self._initialize_moments(
             zeta_range=zeta_range,  # These are [a, b] in the paper

--- a/xfields/slicers/compressed_profile.py
+++ b/xfields/slicers/compressed_profile.py
@@ -221,7 +221,7 @@ class CompressedProfile(xt.BeamElement):
 
         return z_out, moment_out
         
-def get_source_moment_profile(self, moment_name, i_turn,i_source):
+    def get_source_moment_profile(self, moment_name, i_turn,i_source):
         """
         Get the moment profile for a given turn.
 

--- a/xfields/slicers/compressed_profile.py
+++ b/xfields/slicers/compressed_profile.py
@@ -220,3 +220,39 @@ class CompressedProfile(xt.BeamElement):
                           i_start_in_moments_data:i_end_in_moments_data])
 
         return z_out, moment_out
+        
+def get_source_moment_profile(self, moment_name, i_turn,i_source):
+        """
+        Get the moment profile for a given turn.
+
+        Parameters
+        ----------
+        moment_name : str
+            The name of the moment to get
+        i_turn : int
+            The turn index, 0 <= i_turn < self.num_turns
+
+        Returns
+        -------
+        z_out : np.ndarray
+            The z positions within the moment profile
+        moment_out : np.ndarray
+            The moment profile
+        """
+
+        z_out = self._arr2ctx(np.zeros(self._N_1))
+        moment_out = self._arr2ctx(np.zeros(self._N_1))
+        i_moment = self.moments_names.index(moment_name)
+        _z_P = self._z_P or 0
+
+        z_out = (
+            self._z_a + self.dz / 2
+            - i_source * _z_P + self.dz * self._arr2ctx(np.arange(self._N_1)))
+
+        i_start_in_moments_data = (self._N_S - i_source - 1) * self._N_aux
+        i_end_in_moments_data = i_start_in_moments_data + self._N_1
+        moment_out = (
+            self.data[i_moment, i_turn,
+                      i_start_in_moments_data:i_end_in_moments_data])
+
+        return z_out, moment_out


### PR DESCRIPTION
## Description

Added a way to track a single bunch yet adding the impact of wakefields from other bunches assuming a given coupled bunch phase. A test is implemented in a branch of xwakes: https://github.com/xsuite/xwakes/tree/feature/fakeMultiBunch

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
