### PR TITLE
Release/0.25.1

### DIFF
--- a/tests/test_ibs_equilibrium.py
+++ b/tests/test_ibs_equilibrium.py
@@ -154,7 +154,7 @@ def test_equilibrium_vs_analytical_no_constraint(
     xo.assert_allclose(
         result.eq_sr_ibs_gemitt_y,
         result.gemitt_y[0] / (1 - result.Ky[-1] / tw.damping_constants_s[1]),
-        rtol=1e-2,
+        atol=5e-7, rtol=1e-2,
     )
     # Check the longitudinal equilibrium emittance
     xo.assert_allclose(

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -22,11 +22,11 @@ def test_slicer_zeta(test_context):
     slicer_2 = xf.UniformBinSlicer(_context=test_context,
                                    zeta_slice_edges=zeta_slice_edges)
     xo.assert_allclose(slicer_0.zeta_centers,
-                       zeta_centers)
+                       zeta_centers, atol=1e-15)
     xo.assert_allclose(slicer_1.zeta_centers,
-                       zeta_centers)
+                       zeta_centers, atol=1e-15)
     xo.assert_allclose(slicer_2.zeta_centers,
-                       zeta_centers)
+                       zeta_centers, atol=1e-15)
 
 
 @for_all_test_contexts


### PR DESCRIPTION
**Changes:**

- Tightened tolerances as a result of the removal of the default `rtol = atol = 1e-7` setting in `xo.assert_allclose`.