### PR TITLE
Fix IBS kicks examples

### DIFF
--- a/examples/005_ibs/003_tracking_with_kicks.py
+++ b/examples/005_ibs/003_tracking_with_kicks.py
@@ -2,10 +2,11 @@
 # This file is part of the Xfields Package.   #
 # Copyright (c) CERN, 2021.                   #
 # ########################################### #
-import xfields as xf
 import xobjects as xo
 import xpart as xp
 import xtrack as xt
+
+import xfields as xf
 
 context = xo.ContextCpu(omp_num_threads="auto")
 
@@ -35,7 +36,7 @@ ibs_kick = xf.IBSKineticKick(num_slices=50)
 # the kick at the end of the line and configure it. This internally
 # provides the necessary information to the element
 line.configure_intrabeam_scattering(
-    element=ibs_kick, name="ibskick", index=-1, update_every=50
+    element=ibs_kick, name="ibskick", at=line.get_length(), update_every=50
 )
 
 ############################################

--- a/examples/005_ibs/004_tracking_with_kicks_tbt_emittances.py
+++ b/examples/005_ibs/004_tracking_with_kicks_tbt_emittances.py
@@ -2,13 +2,13 @@
 # This file is part of the Xfields Package.   #
 # Copyright (c) CERN, 2021.                   #
 # ########################################### #
-import xfields as xf
-import xobjects as xo
+import matplotlib.pyplot as plt
+import numpy as np
 import xpart as xp
 import xtrack as xt
-from xfields.ibs._formulary import _gemitt_x, _gemitt_y, _sigma_delta, _bunch_length
-import numpy as np
-import matplotlib.pyplot as plt
+
+import xfields as xf
+from xfields.ibs._formulary import _bunch_length, _gemitt_x, _gemitt_y, _sigma_delta
 
 ##########################
 # Load xt.Line from file #
@@ -27,7 +27,7 @@ tw = line.twiss(method="4d")
 # ibs_kick = xf.IBSKineticKick(num_slices=50)
 ibs_kick = xf.IBSAnalyticalKick(formalism="nagaitsev", num_slices=50)
 line.configure_intrabeam_scattering(
-    element=ibs_kick, name="ibskick", index=-1, update_every=50
+    element=ibs_kick, name="ibskick", at=line.get_length(), update_every=50
 )
 
 ################################
@@ -47,7 +47,7 @@ particles = xp.generate_matched_gaussian_bunch(
 )
 
 for turn in range(nturns):
-    print(f"Tracking turn {turn+1}/{nturns}     ", end="\r", flush=True)    
+    print(f"Tracking turn {turn+1}/{nturns}     ", end="\r", flush=True)
     line.track(particles, num_turns=1)
     epsx.append(_gemitt_x(particles, tw.betx[0], tw.dx[0]))
     epsy.append(_gemitt_y(particles, tw.bety[0], tw.dy[0]))

--- a/tests/test_ibs_kicks.py
+++ b/tests/test_ibs_kicks.py
@@ -4,7 +4,7 @@ import xtrack as xt
 from cpymad.madx import Madx
 from ibs_conftest import XTRACK_TEST_DATA, get_ref_particle_from_madx_beam
 from numpy.testing import assert_allclose
-from xobjects.test_helpers import for_all_test_contexts, fix_random_seed
+from xobjects.test_helpers import fix_random_seed, for_all_test_contexts
 
 from xfields.ibs import IBSAnalyticalKick, IBSKineticKick
 from xfields.ibs._formulary import _bunch_length, _gemitt_x, _gemitt_y, _sigma_delta
@@ -236,7 +236,7 @@ def test_track_analytical_kick(test_context):
     cavities = [element for element in line.elements if isinstance(element, xt.Cavity)]
     for cavity in cavities:
         cavity.lag = 180
-    line.configure_intrabeam_scattering(element=ibskick, name="ibskick", at=0, update_every=100)
+    line.configure_intrabeam_scattering(element=ibskick, name="ibskick", at=line.get_length(), update_every=100)
     tw = line.twiss(method="4d")
     particles = xp.generate_matched_gaussian_bunch(
         num_particles=2000,
@@ -286,7 +286,7 @@ def test_track_kinetic_kick(test_context):
     cavities = [element for element in line.elements if isinstance(element, xt.Cavity)]
     for cavity in cavities:
         cavity.lag = 180
-    line.configure_intrabeam_scattering(element=ibskick, name="ibskick", at=0, update_every=100)
+    line.configure_intrabeam_scattering(element=ibskick, name="ibskick", at=line.get_length(), update_every=100)
     tw = line.twiss(method="4d")
     particles = xp.generate_matched_gaussian_bunch(
         num_particles=2000,

--- a/xfields/ibs/_api.py
+++ b/xfields/ibs/_api.py
@@ -140,8 +140,8 @@ def configure_intrabeam_scattering(
     element : IBSKick, optional
         If provided, the element is first inserted in the line,
         before proceeding to configuration. In this case the keyword
-        arguments are passed on to the `line.insert_element` method.
-        This will also discard and rebuild the line tracker.
+        arguments are passed on to the `line.insert` method. This will
+        also discard and rebuild the line tracker.
     update_every : int
         The frequency at which to recompute the kick coefficients, in
         number of turns. They will be computed at the first turn of
@@ -149,8 +149,8 @@ def configure_intrabeam_scattering(
 
     **kwargs : dict, optional
         Required if an element is provided. Keyword arguments are
-        passed to the `line.insert_element()` method according to
-        `line.insert_element(element=element, **kwargs)`.
+        passed to the `line.insert()` method according to
+        `line.insert(obj=element, what=name, **kwargs)`.
 
     Raises
     ------


### PR DESCRIPTION
The recent changes to adapt from `line.insert_element` to `line.insert` have left some IBS scripts in a non-running state, due to kwargs being passed by `line.configure_intrabeam_scattering`.

This is fixed in this PR. Specifically, the previous use of `index=-1` to install the element at the end of the line is replaced with `at=line.get_length()`.

Docstring is adapted too.