### PR TITLE
Fix flakiness in `test_beambeam3d_beamstrahlung_pic`

### DIFF
--- a/tests/test_beamstrahlung_pic.py
+++ b/tests/test_beamstrahlung_pic.py
@@ -9,12 +9,13 @@ import xtrack as xt
 import xfields as xf
 import xpart as xp
 
-from xobjects.test_helpers import for_all_test_contexts
+from xobjects.test_helpers import fix_random_seed, for_all_test_contexts
 
 test_data_folder = pathlib.Path(
     __file__).parent.joinpath('../test_data').absolute()
 
 @for_all_test_contexts(excluding="ContextPyopencl")
+@fix_random_seed(237659236)
 def test_beambeam3d_beamstrahlung_pic(test_context):
 
     if isinstance(test_context, xo.ContextCupy):


### PR DESCRIPTION
## Description

Fix random seed to remove flakiness in `test_beambeam3d_beamstrahlung_pic`.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
