### PR TITLE
Use beam covariance API for beam-beam setup

### DIFF
--- a/xfields/config_tools/beambeam_config_tools/config_tools.py
+++ b/xfields/config_tools/beambeam_config_tools/config_tools.py
@@ -94,7 +94,8 @@ def configure_beam_beam_elements(bb_df_cw, bb_df_acw, line_cw, line_acw,
             assert sv_ip['Y', ip_name] == 0
             assert sv_ip['Z', ip_name] == 0
 
-        sigmas = twiss.get_betatron_sigmas(nemitt_x=nemitt_x, nemitt_y=nemitt_y)
+        sigmas = twiss.get_beam_covariance(
+            nemitt_x=nemitt_x, nemitt_y=nemitt_y)
 
         bb_df['self_num_particles'] = num_particles * bb_df['self_frac_of_bunch']
 


### PR DESCRIPTION
**Change:**
- Update following xtrack deprecation